### PR TITLE
Support multi-dataset training and evaluation

### DIFF
--- a/configs/train_video2mesh.yaml
+++ b/configs/train_video2mesh.yaml
@@ -1,0 +1,88 @@
+### train_video2mesh.yaml ###
+# Training config for the video2mesh temporal DiT (TripoSG TripoSGDiTModel4D).
+#
+# This trainer expects the dataset to be preprocessed by
+# preprocess/preprocess_data.py, which writes per-sample .npz files under
+# <dataset_root>/npz_train/ containing:
+#     latent:      [T, 2048, 64]   (VAE-encoded mesh latent)
+#     image_embed: [T, 257, 1024]  (frozen DinoV2 image embedding)
+#
+# Only the transformer is trained (the VAE + image encoder are frozen and
+# already applied during preprocessing).
+
+name: "Video2Mesh training"
+
+runtime:
+  device: "cuda"
+  seed: 42
+  # AMP compute dtype. "bfloat16" is safer for DiT; "float16" is faster on older GPUs.
+  amp_dtype: "bfloat16"
+  debug: false
+
+output:
+  checkpoint_root: ./checkpoints/video2mesh
+
+experiment:
+  exp: video2mesh_base
+
+model:
+  target: models.v1.video2mesh.triposg_transformer.TripoSGDiTModel4D
+  params:
+    num_attention_heads: 16
+    width: 2048
+    in_channels: 64
+    num_layers: 21
+    cross_attention_dim: 1024
+    use_cross_attention_2: false
+    cross_attention_2_dim: null
+
+  attention_kwargs:
+    seq_len: 16
+    selfatt_temporal_layer_flag: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+    selfatt_temporal: true
+    crossatt2_temporal: true
+    selfatt_slidwindow: 3
+    crossatt2_slidwindow: 5
+
+train:
+  batch_size: 1
+  epochs: 200
+  grad_accum_steps: 4
+  lr: 1.0e-4
+  weight_decay: 0.01
+  betas: [0.9, 0.999]
+  max_grad_norm: 1.0
+  max_ckpt: 5
+  num_workers_train: 4
+  test_every: 1
+  pretrain_ckpt: null             # optional: load transformer weights partially
+  use_grad_checkpoint: true       # TripoSG DiT is large; enable by default
+  find_unused_parameters: false
+
+  loss:
+    # Flow-matching loss on transformer output vs. (noise - data).
+    loss_type: "l2"               # l1 | l2 | smooth_l1
+    # Sampling strategy for the flow-matching time parameter u in (0, 1).
+    t_schedule: "logit_normal"    # uniform | logit_normal
+    t_mean: 0.0                   # only used for logit_normal
+    t_std: 1.0                    # only used for logit_normal
+    # Scales u -> model timestep. TripoSG DiT uses positional embeddings on
+    # the [0, 1000] range, matching its inference scheduler.
+    timestep_scale: 1000.0
+
+eval:
+  batch_size: 1
+  num_workers: 2
+  best_metric_name: "fm_loss"
+
+data:
+  # Directory containing the preprocessed .npz training files.
+  npz_dir: datasets/zoo1030/npz_train
+  # Optional split JSON with {"train": [...], "test": [...]} of sample ids
+  # (relative path without .npz). If null, everything is used for training
+  # and evaluation is skipped.
+  split_json: null
+  # Skip any sample whose underlying clip has fewer than this many frames.
+  min_frames: null
+  preload_all: false
+  debug_limit: null

--- a/configs/train_video2mesh.yaml
+++ b/configs/train_video2mesh.yaml
@@ -1,21 +1,21 @@
 ### train_video2mesh.yaml ###
-# Training config for the video2mesh temporal DiT (TripoSG TripoSGDiTModel4D).
+# Training config for the video2mesh temporal DiT (TripoSGDiTModel4D).
 #
-# This trainer expects the dataset to be preprocessed by
-# preprocess/preprocess_data.py, which writes per-sample .npz files under
-# <dataset_root>/npz_train/ containing:
-#     latent:      [T, 2048, 64]   (VAE-encoded mesh latent)
-#     image_embed: [T, 257, 1024]  (frozen DinoV2 image embedding)
+# Mirrors the CLI flags of the reference train_s2_0821_ddp.py script but
+# expressed as YAML and split into the mocapv2 project's usual sections.
 #
-# Only the transformer is trained (the VAE + image encoder are frozen and
-# already applied during preprocessing).
+# Expects the dataset to be preprocessed by preprocess/preprocess_data.py
+# into per-sample .npz files containing:
+#     image_embed: [T, 257, 1024]
+#     latent:      [T, 2048, 64]
 
 name: "Video2Mesh training"
 
 runtime:
   device: "cuda"
   seed: 42
-  # AMP compute dtype. "bfloat16" is safer for DiT; "float16" is faster on older GPUs.
+  # AMP compute dtype for autocast. bfloat16 is safer for DiT; use float16
+  # if your GPU lacks bf16 support.
   amp_dtype: "bfloat16"
   debug: false
 
@@ -26,19 +26,15 @@ experiment:
   exp: video2mesh_base
 
 model:
-  target: models.v1.video2mesh.triposg_transformer.TripoSGDiTModel4D
-  params:
-    num_attention_heads: 16
-    width: 2048
-    in_channels: 64
-    num_layers: 21
-    cross_attention_dim: 1024
-    use_cross_attention_2: false
-    cross_attention_2_dim: null
+  # Pretrained TripoSG DiT transformer directory (config.json + weights).
+  # The scheduler_config_path under `train` is typically a sibling folder.
+  pretrained_path: ./checkpoints/TripoSG/transformer
 
+  # Temporal attention design. seq_len is overridden at runtime from
+  # data.seq_len so there's one source of truth.
   attention_kwargs:
     seq_len: 16
-    selfatt_temporal_layer_flag: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+    selfatt_temporal_layer_flag: []
     selfatt_temporal: true
     crossatt2_temporal: true
     selfatt_slidwindow: 3
@@ -46,43 +42,60 @@ model:
 
 train:
   batch_size: 1
-  epochs: 200
-  grad_accum_steps: 4
-  lr: 1.0e-4
-  weight_decay: 0.01
+  num_epochs: 10000
+  learning_rate: 1.0e-4
   betas: [0.9, 0.999]
+  weight_decay: 0.0
+  gradient_accumulation_steps: 1
   max_grad_norm: 1.0
-  max_ckpt: 5
-  num_workers_train: 4
-  test_every: 1
-  pretrain_ckpt: null             # optional: load transformer weights partially
-  use_grad_checkpoint: true       # TripoSG DiT is large; enable by default
+  save_every: 300          # save checkpoint every N global steps
+  log_every: 10
+  num_workers: 4
+  max_ckpt: 5              # keep only the most recent N checkpoint_step_* dirs (0 = keep all)
+  resume: true             # auto-resume from latest checkpoint_step_* under output dir
+  use_amp: true
+  gradient_checkpointing: true
   find_unused_parameters: false
 
-  loss:
-    # Flow-matching loss on transformer output vs. (noise - data).
-    loss_type: "l2"               # l1 | l2 | smooth_l1
-    # Sampling strategy for the flow-matching time parameter u in (0, 1).
-    t_schedule: "logit_normal"    # uniform | logit_normal
-    t_mean: 0.0                   # only used for logit_normal
-    t_std: 1.0                    # only used for logit_normal
-    # Scales u -> model timestep. TripoSG DiT uses positional embeddings on
-    # the [0, 1000] range, matching its inference scheduler.
-    timestep_scale: 1000.0
+  # RectifiedFlow scheduler (same config that ships with TripoSG).
+  scheduler_config_path: ./checkpoints/TripoSG/scheduler/scheduler_config.json
 
-eval:
-  batch_size: 1
-  num_workers: 2
-  best_metric_name: "fm_loss"
+  # CFG unconditional dropout: replace the image embedding with zeros for
+  # this fraction of the batch to train unconditional guidance.
+  uncond_dropout_prob: 0.1
+
+  # Timestep sampling density used by RectifiedFlowScheduler.
+  # One of: logit_normal | logit_normal_dist | mode | uniform
+  timestep_sampling_weighting: "logit_normal"
+  logit_mean: 0.0
+  logit_std: 1.0
+
+  # Per-sample loss weighting: sigma_sqrt | cosmap | none
+  loss_weighting_scheme: "sigma_sqrt"
+
+lora:
+  enable: false
+  rank: 4
+  alpha: 4           # defaults to rank if omitted in code
+  dropout: 0.0
+  target_mode: "all" # "all" | "qkv"
+  # On every save, also emit a CPU-merged full-weight transformer/ folder
+  # alongside the LoRA adapter so inference can use either one directly.
+  merge_on_save: true
 
 data:
-  # Directory containing the preprocessed .npz training files.
-  npz_dir: datasets/zoo1030/npz_train
-  # Optional split JSON with {"train": [...], "test": [...]} of sample ids
-  # (relative path without .npz). If null, everything is used for training
-  # and evaluation is skipped.
-  split_json: null
-  # Skip any sample whose underlying clip has fewer than this many frames.
-  min_frames: null
-  preload_all: false
-  debug_limit: null
+  # One or more preprocessed .npz directories (comma-separated string or list).
+  train_dirs:
+    - ./datasets/zoo1030/npz_train
+  # Optional held-out sequences. Either a full JSON path, or a name such as
+  # "selected_test_split" that resolves to
+  # <parent-of-first-train-dir>/selected_test_split.json. The JSON can be
+  # either a flat list of dir-names or {"test": [...], ...} dict.
+  skip_json: null
+
+  seq_len: 16
+  hop: 1             # stride between consecutive windows (in frames)
+  frame_step: 1      # stride inside a window (1 = consecutive frames)
+  drop_last: true
+  preload: false
+  num_threads: 32

--- a/configs/train_video2pose2rot.yaml
+++ b/configs/train_video2pose2rot.yaml
@@ -34,7 +34,7 @@ model:
 
     p2r_cfg:
       target: models.v2.pose2rot.model.Pose2RotMemoryRestModel
-      params: 
+      params:
         q_dim: 256
         rest_layers: 4
         pose_layers: 4
@@ -51,7 +51,7 @@ model:
         pose_use_graph: true
         use_grad_checkpoint: false
         decoder_use_cross_layers: 6
-    
+
   attention_kwargs:
     seq_len: 24
     selfatt_temporal_layer_flag: []
@@ -84,7 +84,7 @@ train:
     acc_loss_type: smooth_l1
     pose_loss_type: l2
     pose_vel_loss_type: l1
-  
+
   weight:
     root_wt: 0.1
     fk_wt: 0.0
@@ -101,16 +101,33 @@ eval:
   batch_size: 1
   num_workers: 2
   preload_all: false
+  # Default splits used when a dataset entry below doesn't list `test_splits`.
   split_groups: ["seen", "rare", "unseen"]
+  # Best-checkpoint selector is now a (dataset, split, metric) tuple.
+  best_metric_dataset: "zoo1030"
   best_metric_split: "seen"
   best_metric_name: "rot_l1"
 
 data:
+  # shared across all datasets
   seq_len: 24
-  bvh_dir: datasets/zoo1030/bvh
   cache_scale: true
   limit_species_debug: []
   mmap: true
-  split_json: datasets/zoo1030/selected_test_split1010.json
-  train_memory_pkl_path: datasets/zoo1030/cache/species_fps_memory_yAll/fps_select_by_rot_32.pkl
-  test_memory_pkl_path: datasets/zoo1030/cache/species_fps_memory_yAll/fps_select_by_rot_32.pkl
+
+  # List of datasets. They are concatenated for training, and each one is
+  # evaluated independently on its own `test_splits`.
+  datasets:
+    - name: zoo1030
+      bvh_dir: datasets/zoo1030/bvh
+      split_json: datasets/zoo1030/selected_test_split1010.json
+      train_memory_pkl_path: datasets/zoo1030/cache/species_fps_memory_yAll/fps_select_by_rot_32.pkl
+      test_memory_pkl_path: datasets/zoo1030/cache/species_fps_memory_yAll/fps_select_by_rot_32.pkl
+      test_splits: ["seen", "rare", "unseen"]
+
+    - name: obj1k
+      bvh_dir: datasets/obj1k/bvh
+      split_json: datasets/obj1k/select_test_obj1k.json
+      train_memory_pkl_path: null
+      test_memory_pkl_path: null
+      test_splits: ["seen"]

--- a/configs/train_video2pose2rot_v2pv3.yaml
+++ b/configs/train_video2pose2rot_v2pv3.yaml
@@ -100,16 +100,33 @@ eval:
   batch_size: 1
   num_workers: 2
   preload_all: false
+  # Default splits used when a dataset entry below doesn't list `test_splits`.
   split_groups: ["seen", "rare", "unseen"]
+  # Best-checkpoint selector is now a (dataset, split, metric) tuple.
+  best_metric_dataset: "zoo1030"
   best_metric_split: "seen"
   best_metric_name: "rot_l1"
 
 data:
+  # shared across all datasets
   seq_len: 24
-  bvh_dir: datasets/zoo1030/bvh
   cache_scale: true
   limit_species_debug: []
   mmap: true
-  split_json: datasets/zoo1030/selected_test_split1010.json
-  train_memory_pkl_path: datasets/zoo1030/cache/species_fps_memory_yAll/fps_select_by_rot_32.pkl
-  test_memory_pkl_path: datasets/zoo1030/cache/species_fps_memory_yAll/fps_select_by_rot_32.pkl
+
+  # List of datasets. They are concatenated for training, and each one is
+  # evaluated independently on its own `test_splits`.
+  datasets:
+    - name: zoo1030
+      bvh_dir: datasets/zoo1030/bvh
+      split_json: datasets/zoo1030/selected_test_split1010.json
+      train_memory_pkl_path: datasets/zoo1030/cache/species_fps_memory_yAll/fps_select_by_rot_32.pkl
+      test_memory_pkl_path: datasets/zoo1030/cache/species_fps_memory_yAll/fps_select_by_rot_32.pkl
+      test_splits: ["seen", "rare", "unseen"]
+
+    - name: obj1k
+      bvh_dir: datasets/obj1k/bvh
+      split_json: datasets/obj1k/select_test_obj1k.json
+      train_memory_pkl_path: null
+      test_memory_pkl_path: null
+      test_splits: ["seen"]

--- a/data/loader_v1_mesh.py
+++ b/data/loader_v1_mesh.py
@@ -1,0 +1,187 @@
+
+### loader_v1_mesh.py ###
+# Dataset for training video2mesh (TripoSG-style flow-matching DiT).
+#
+# Consumes the .npz files produced by preprocess/preprocess_data.py, which
+# contain per-frame pairs of (VAE-encoded mesh latent, DinoV2 image embedding).
+# Each .npz holds:
+#     latent:      [T, num_tokens, latent_dim]       e.g. [T, 2048, 64]
+#     image_embed: [T, cond_tokens, cond_dim]        e.g. [T, 257, 1024]
+#
+# The dataset walks a root directory recursively for .npz files, applies an
+# optional JSON split, and yields fixed-length windows suitable for the
+# temporal DiT in model/v1/video2mesh.
+
+import json
+import os
+import random
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+def _find_all_npz(root: str) -> List[str]:
+    out = []
+    for dirpath, _, filenames in os.walk(root):
+        for f in filenames:
+            if f.endswith(".npz"):
+                out.append(os.path.join(dirpath, f))
+    out.sort()
+    return out
+
+
+def _load_split_ids(split_json: Optional[str], split_mode: str) -> Optional[set]:
+    """
+    Load a set of allowed sample ids from a split JSON.
+
+    Expected JSON layout (flexible):
+        {"train": [...], "test": [...]} -> list of relative paths or ids
+    Returns None when no split filtering should be applied.
+    """
+    if split_json is None or not os.path.exists(split_json):
+        return None
+
+    with open(split_json, "r") as f:
+        data = json.load(f)
+
+    if isinstance(data, list):
+        ids = data
+    elif isinstance(data, dict):
+        ids = data.get(split_mode, None)
+        if ids is None:
+            return None
+    else:
+        return None
+
+    return set(str(x) for x in ids)
+
+
+class VideoMeshLatentDataset(Dataset):
+    """
+    Dataset of pre-computed (mesh latent, image embedding) sequences for
+    training the video2mesh temporal DiT with flow matching.
+    """
+
+    def __init__(
+        self,
+        npz_dir: str,
+        window: int = 16,
+        split_json: Optional[str] = None,
+        split_mode: str = "train",
+        min_frames: Optional[int] = None,
+        preload_all: bool = False,
+        debug_limit: Optional[int] = None,
+    ):
+        super().__init__()
+
+        self.npz_dir = npz_dir
+        self.window = int(window)
+        self.split_mode = split_mode
+        self.preload_all = preload_all
+        self.min_frames = min_frames if min_frames is not None else self.window
+
+        all_npz = _find_all_npz(npz_dir)
+        allowed = _load_split_ids(split_json, split_mode)
+
+        items: List[Dict[str, Any]] = []
+        for p in all_npz:
+            rel = os.path.relpath(p, npz_dir)
+            sample_id = os.path.splitext(rel)[0]  # drop .npz
+
+            if allowed is not None and sample_id not in allowed and rel not in allowed:
+                continue
+
+            items.append({
+                "path": p,
+                "rel": rel,
+                "sample_id": sample_id,
+            })
+
+            if debug_limit is not None and len(items) >= debug_limit:
+                break
+
+        # Filter + cache length metadata.
+        self.items: List[Dict[str, Any]] = []
+        self._preloaded: Dict[str, Dict[str, np.ndarray]] = {}
+
+        for it in items:
+            try:
+                with np.load(it["path"], allow_pickle=False) as z:
+                    n = z["latent"].shape[0]
+                    ne = z["image_embed"].shape[0]
+                    if n != ne:
+                        continue
+                    if n < self.min_frames:
+                        continue
+                    it["num_frames"] = int(n)
+                    it["latent_shape"] = tuple(z["latent"].shape)
+                    it["embed_shape"] = tuple(z["image_embed"].shape)
+                    if preload_all:
+                        self._preloaded[it["path"]] = {
+                            "latent": z["latent"].astype(np.float32),
+                            "image_embed": z["image_embed"].astype(np.float32),
+                        }
+                self.items.append(it)
+            except Exception as e:
+                # Skip corrupted or incomplete files silently.
+                continue
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def _load(self, it: Dict[str, Any]):
+        if it["path"] in self._preloaded:
+            arrs = self._preloaded[it["path"]]
+            return arrs["latent"], arrs["image_embed"]
+        with np.load(it["path"], allow_pickle=False) as z:
+            latent = z["latent"].astype(np.float32)
+            image_embed = z["image_embed"].astype(np.float32)
+        return latent, image_embed
+
+    def _pick_window(self, n: int) -> int:
+        if n <= self.window:
+            return 0
+        if self.split_mode == "train":
+            return random.randint(0, n - self.window)
+        # Deterministic window for eval: center crop.
+        return max(0, (n - self.window) // 2)
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        it = self.items[idx]
+        latent, image_embed = self._load(it)
+        n = latent.shape[0]
+
+        start = self._pick_window(n)
+        end = start + self.window
+
+        lat_win = latent[start:end]            # [T, N, D_latent]
+        img_win = image_embed[start:end]       # [T, C, D_cond]
+
+        # Pad at the end if the clip is shorter than the window.
+        if lat_win.shape[0] < self.window:
+            pad = self.window - lat_win.shape[0]
+            lat_win = np.concatenate(
+                [lat_win, np.repeat(lat_win[-1:], pad, axis=0)], axis=0
+            )
+            img_win = np.concatenate(
+                [img_win, np.repeat(img_win[-1:], pad, axis=0)], axis=0
+            )
+
+        return {
+            "latent": torch.from_numpy(lat_win).float(),          # [T, N, D_latent]
+            "image_embed": torch.from_numpy(img_win).float(),     # [T, C, D_cond]
+            "sample_id": it["sample_id"],
+            "start": start,
+        }
+
+
+def collate_video_mesh(batch: List[Dict[str, Any]]) -> Dict[str, Any]:
+    out = {
+        "latent": torch.stack([b["latent"] for b in batch], dim=0),           # [B, T, N, D]
+        "image_embed": torch.stack([b["image_embed"] for b in batch], dim=0), # [B, T, C, D]
+        "sample_id": [b["sample_id"] for b in batch],
+        "start": torch.tensor([b["start"] for b in batch], dtype=torch.long),
+    }
+    return out

--- a/data/loader_v1_mesh.py
+++ b/data/loader_v1_mesh.py
@@ -1,187 +1,273 @@
 
 ### loader_v1_mesh.py ###
-# Dataset for training video2mesh (TripoSG-style flow-matching DiT).
+# Dataset for training the video2mesh temporal DiT with RectifiedFlow.
 #
-# Consumes the .npz files produced by preprocess/preprocess_data.py, which
-# contain per-frame pairs of (VAE-encoded mesh latent, DinoV2 image embedding).
-# Each .npz holds:
-#     latent:      [T, num_tokens, latent_dim]       e.g. [T, 2048, 64]
-#     image_embed: [T, cond_tokens, cond_dim]        e.g. [T, 257, 1024]
+# Consumes .npz files produced by preprocess/preprocess_data.py, each holding:
+#     image_embed: [T, 257, 1024]   (frozen DinoV2 embedding, per-frame)
+#     latent:      [T, 2048, 64]    (VAE-encoded mesh latent, per-frame)
 #
-# The dataset walks a root directory recursively for .npz files, applies an
-# optional JSON split, and yields fixed-length windows suitable for the
-# temporal DiT in model/v1/video2mesh.
+# Sliding windows of length ``seq_len`` are produced from every sequence.
+# A JSON skip-list (typically the test split) can be applied to drop
+# held-out sequences. Meta information (per-file frame count) is cached on
+# disk so subsequent runs don't need to re-scan every .npz.
 
 import json
 import os
-import random
-from typing import Any, Dict, List, Optional
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Optional, Tuple
 
 import numpy as np
 import torch
+import torch.distributed as dist
 from torch.utils.data import Dataset
+from tqdm import tqdm
 
 
-def _find_all_npz(root: str) -> List[str]:
-    out = []
-    for dirpath, _, filenames in os.walk(root):
-        for f in filenames:
-            if f.endswith(".npz"):
-                out.append(os.path.join(dirpath, f))
-    out.sort()
-    return out
+def _natural_sort_key(s: str):
+    return [int(t) if t.isdigit() else t.lower() for t in re.split(r"(\d+)", s)]
 
 
-def _load_split_ids(split_json: Optional[str], split_mode: str) -> Optional[set]:
+def _print_rank0(*args, **kwargs):
+    if not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0:
+        print(*args, **kwargs)
+
+
+def load_or_cache_meta(
+    files: List[str],
+    num_threads: int = 16,
+    preload: bool = False,
+    mmap_mode: Optional[str] = "r",
+    cache_path: Optional[str] = None,
+):
     """
-    Load a set of allowed sample ids from a split JSON.
-
-    Expected JSON layout (flexible):
-        {"train": [...], "test": [...]} -> list of relative paths or ids
-    Returns None when no split filtering should be applied.
+    Load per-file meta (``T``) from .npz files, caching the result as JSON.
+    DDP safe: rank 0 does the scan + write, other ranks wait on a barrier
+    and then read the cache.
     """
-    if split_json is None or not os.path.exists(split_json):
-        return None
+    distributed = dist.is_available() and dist.is_initialized()
+    rank = dist.get_rank() if distributed else 0
+    is_main = rank == 0
 
-    with open(split_json, "r") as f:
-        data = json.load(f)
+    def load_meta_single(p):
+        if preload:
+            arr = np.load(p, mmap_mode=None)
+            img = np.asarray(arr["image_embed"])
+            lat = np.asarray(arr["latent"])
+            if img.shape[0] != lat.shape[0]:
+                raise ValueError(f"Frame count mismatch in {p}")
+            return {"img": img, "lat": lat, "T": int(img.shape[0]), "path": p}
+        else:
+            arr = np.load(p, mmap_mode=mmap_mode)
+            try:
+                T = int(arr["image_embed"].shape[0])
+            finally:
+                arr.close()
+            return {"path": p, "T": T}
 
-    if isinstance(data, list):
-        ids = data
-    elif isinstance(data, dict):
-        ids = data.get(split_mode, None)
-        if ids is None:
-            return None
-    else:
-        return None
+    if cache_path is None:
+        first_dir = os.path.dirname(os.path.commonpath(files))
+        cache_path = os.path.join(first_dir, "dataset_meta_cache.json")
 
-    return set(str(x) for x in ids)
+    if is_main:
+        if os.path.exists(cache_path):
+            try:
+                with open(cache_path, "r") as f:
+                    cached = json.load(f)
+                if isinstance(cached, list) and all("path" in m and "T" in m for m in cached):
+                    _print_rank0(
+                        f"[INFO][Rank0] Loaded meta cache: {len(cached)} files "
+                        f"({cache_path})"
+                    )
+                    if distributed:
+                        dist.barrier()
+                    return cached
+                else:
+                    _print_rank0(f"[WARN][Rank0] cache structure invalid, rescanning.")
+            except Exception as e:
+                _print_rank0(f"[WARN][Rank0] failed to read cache: {e}, rescanning.")
+
+        _print_rank0(
+            f"[INFO][Rank0] Scanning meta for {len(files)} files "
+            f"(threads={num_threads})"
+        )
+        loaded = []
+        with ThreadPoolExecutor(max_workers=num_threads) as ex:
+            futures = {ex.submit(load_meta_single, p): p for p in files}
+            for f in tqdm(as_completed(futures), total=len(futures), ncols=100, desc="[Load meta]"):
+                try:
+                    loaded.append(f.result())
+                except Exception as e:
+                    _print_rank0(f"[WARN] failed {futures[f]}: {e}")
+        _print_rank0(f"[INFO][Rank0] meta loaded: {len(loaded)} files")
+
+        try:
+            with open(cache_path, "w") as f:
+                json.dump(loaded, f, indent=2)
+            _print_rank0(f"[INFO][Rank0] meta cached to {cache_path}")
+        except Exception as e:
+            _print_rank0(f"[WARN][Rank0] failed to save cache: {e}")
+
+        if distributed:
+            dist.barrier()
+        return loaded
+
+    # non-main ranks: wait and read
+    if distributed:
+        dist.barrier()
+    with open(cache_path, "r") as f:
+        return json.load(f)
 
 
-class VideoMeshLatentDataset(Dataset):
+class FullSequenceLatentDataset(Dataset):
     """
-    Dataset of pre-computed (mesh latent, image embedding) sequences for
-    training the video2mesh temporal DiT with flow matching.
+    Sliding-window dataset of (image_embed, latent) pairs from preprocessed
+    .npz files.
     """
 
     def __init__(
         self,
-        npz_dir: str,
-        window: int = 16,
-        split_json: Optional[str] = None,
-        split_mode: str = "train",
-        min_frames: Optional[int] = None,
-        preload_all: bool = False,
-        debug_limit: Optional[int] = None,
+        npz_dirs,
+        seq_len: int = 16,
+        image_key: str = "image_embed",
+        latent_key: str = "latent",
+        frame_step: int = 1,
+        hop: Optional[int] = None,
+        drop_last: bool = True,
+        preload: bool = False,
+        mmap_mode: Optional[str] = "r",
+        num_threads: int = 32,
+        skip_json: Optional[str] = None,
     ):
         super().__init__()
+        self.seq_len = int(seq_len)
+        self.image_key = image_key
+        self.latent_key = latent_key
+        self.frame_step = int(frame_step)
+        self.hop = int(hop) if hop is not None else self.seq_len
+        self.drop_last = drop_last
+        self.preload = preload
+        self.mmap_mode = None if preload else mmap_mode
+        self.num_threads = num_threads
 
-        self.npz_dir = npz_dir
-        self.window = int(window)
-        self.split_mode = split_mode
-        self.preload_all = preload_all
-        self.min_frames = min_frames if min_frames is not None else self.window
+        # Gather .npz files
+        if isinstance(npz_dirs, str):
+            npz_dirs = [d.strip() for d in npz_dirs.split(",") if d.strip()]
 
-        all_npz = _find_all_npz(npz_dir)
-        allowed = _load_split_ids(split_json, split_mode)
+        files: List[str] = []
+        for npz_dir in npz_dirs:
+            if not os.path.isdir(npz_dir):
+                raise ValueError(f"{npz_dir} is not a directory")
+            for root, _, fnames in os.walk(npz_dir):
+                for f in fnames:
+                    if f.endswith(".npz"):
+                        files.append(os.path.join(root, f))
+        files.sort(key=_natural_sort_key)
 
-        items: List[Dict[str, Any]] = []
-        for p in all_npz:
-            rel = os.path.relpath(p, npz_dir)
-            sample_id = os.path.splitext(rel)[0]  # drop .npz
+        # Apply skip list (held-out sequences)
+        if skip_json is not None:
+            skip_path = skip_json
+            if not os.path.isabs(skip_path):
+                # resolve relative to the first dataset dir
+                skip_path = os.path.join(os.path.dirname(npz_dirs[0]), skip_json)
+                if not skip_path.endswith(".json"):
+                    skip_path = skip_path + ".json"
 
-            if allowed is not None and sample_id not in allowed and rel not in allowed:
+            if os.path.exists(skip_path):
+                with open(skip_path, "r") as f:
+                    skip_dict = json.load(f)
+                skip_list = set()
+                if isinstance(skip_dict, dict):
+                    for v in skip_dict.values():
+                        if isinstance(v, list):
+                            skip_list.update(v)
+                elif isinstance(skip_dict, list):
+                    skip_list.update(skip_dict)
+
+                _print_rank0(f"[INFO] skip list: {len(skip_list)} sequences ({skip_path})")
+                kept = [
+                    f for f in files
+                    if os.path.basename(os.path.dirname(f)) not in skip_list
+                ]
+                _print_rank0(
+                    f"[DEBUG] original files={len(files)} kept={len(kept)}"
+                )
+                files = kept
+
+        if not files:
+            raise FileNotFoundError(f"No npz files found under {npz_dirs}")
+        self.files = files
+
+        cache_path = os.path.join(
+            os.path.dirname(npz_dirs[0]), "dataset_meta_cache.json"
+        )
+        self._loaded = load_or_cache_meta(
+            self.files,
+            num_threads=self.num_threads,
+            preload=self.preload,
+            mmap_mode=self.mmap_mode,
+            cache_path=cache_path,
+        )
+
+        # Build sliding window index
+        self._index: List[Tuple[int, int]] = []
+        for fi, meta in enumerate(self._loaded):
+            T = meta["T"]
+            max_start = T - (self.seq_len - 1) * self.frame_step
+            end = max(0, max_start) if self.drop_last else T
+            if self.drop_last and max_start <= 0:
                 continue
+            start = 0
+            while start < end:
+                self._index.append((fi, start))
+                start += self.hop
 
-            items.append({
-                "path": p,
-                "rel": rel,
-                "sample_id": sample_id,
-            })
+        if not self._index:
+            if self.drop_last:
+                raise ValueError(
+                    "No valid sequence windows. Try smaller seq_len/frame_step or drop_last=False."
+                )
+            self._index.append((0, 0))
 
-            if debug_limit is not None and len(items) >= debug_limit:
-                break
+    def __len__(self):
+        return len(self._index)
 
-        # Filter + cache length metadata.
-        self.items: List[Dict[str, Any]] = []
-        self._preloaded: Dict[str, Dict[str, np.ndarray]] = {}
+    def _load_arrays(self, fi: int):
+        meta = self._loaded[fi]
+        if self.preload:
+            return meta["img"], meta["lat"]
+        arr = np.load(meta["path"], mmap_mode=self.mmap_mode)
+        img = arr[self.image_key]
+        lat = arr[self.latent_key]
+        return img, lat
 
-        for it in items:
-            try:
-                with np.load(it["path"], allow_pickle=False) as z:
-                    n = z["latent"].shape[0]
-                    ne = z["image_embed"].shape[0]
-                    if n != ne:
-                        continue
-                    if n < self.min_frames:
-                        continue
-                    it["num_frames"] = int(n)
-                    it["latent_shape"] = tuple(z["latent"].shape)
-                    it["embed_shape"] = tuple(z["image_embed"].shape)
-                    if preload_all:
-                        self._preloaded[it["path"]] = {
-                            "latent": z["latent"].astype(np.float32),
-                            "image_embed": z["image_embed"].astype(np.float32),
-                        }
-                self.items.append(it)
-            except Exception as e:
-                # Skip corrupted or incomplete files silently.
-                continue
+    def __getitem__(self, idx: int):
+        fi, start = self._index[idx]
+        img_np, lat_np = self._load_arrays(fi)
+        T = img_np.shape[0]
+        idxs = start + np.arange(self.seq_len) * self.frame_step
 
-    def __len__(self) -> int:
-        return len(self.items)
+        if self.drop_last:
+            img_win = img_np[idxs]
+            lat_win = lat_np[idxs]
+        else:
+            valid = idxs < T
+            idxs = idxs[valid]
+            img_win = img_np[idxs]
+            lat_win = lat_np[idxs]
+            if img_win.shape[0] < self.seq_len:
+                pad = self.seq_len - img_win.shape[0]
+                img_win = np.concatenate([img_win, np.repeat(img_win[-1:], pad, axis=0)], axis=0)
+                lat_win = np.concatenate([lat_win, np.repeat(lat_win[-1:], pad, axis=0)], axis=0)
 
-    def _load(self, it: Dict[str, Any]):
-        if it["path"] in self._preloaded:
-            arrs = self._preloaded[it["path"]]
-            return arrs["latent"], arrs["image_embed"]
-        with np.load(it["path"], allow_pickle=False) as z:
-            latent = z["latent"].astype(np.float32)
-            image_embed = z["image_embed"].astype(np.float32)
-        return latent, image_embed
+        return (
+            torch.from_numpy(np.asarray(img_win)).float(),
+            torch.from_numpy(np.asarray(lat_win)).float(),
+        )
 
-    def _pick_window(self, n: int) -> int:
-        if n <= self.window:
-            return 0
-        if self.split_mode == "train":
-            return random.randint(0, n - self.window)
-        # Deterministic window for eval: center crop.
-        return max(0, (n - self.window) // 2)
-
-    def __getitem__(self, idx: int) -> Dict[str, Any]:
-        it = self.items[idx]
-        latent, image_embed = self._load(it)
-        n = latent.shape[0]
-
-        start = self._pick_window(n)
-        end = start + self.window
-
-        lat_win = latent[start:end]            # [T, N, D_latent]
-        img_win = image_embed[start:end]       # [T, C, D_cond]
-
-        # Pad at the end if the clip is shorter than the window.
-        if lat_win.shape[0] < self.window:
-            pad = self.window - lat_win.shape[0]
-            lat_win = np.concatenate(
-                [lat_win, np.repeat(lat_win[-1:], pad, axis=0)], axis=0
-            )
-            img_win = np.concatenate(
-                [img_win, np.repeat(img_win[-1:], pad, axis=0)], axis=0
-            )
-
-        return {
-            "latent": torch.from_numpy(lat_win).float(),          # [T, N, D_latent]
-            "image_embed": torch.from_numpy(img_win).float(),     # [T, C, D_cond]
-            "sample_id": it["sample_id"],
-            "start": start,
-        }
-
-
-def collate_video_mesh(batch: List[Dict[str, Any]]) -> Dict[str, Any]:
-    out = {
-        "latent": torch.stack([b["latent"] for b in batch], dim=0),           # [B, T, N, D]
-        "image_embed": torch.stack([b["image_embed"] for b in batch], dim=0), # [B, T, C, D]
-        "sample_id": [b["sample_id"] for b in batch],
-        "start": torch.tensor([b["start"] for b in batch], dtype=torch.long),
-    }
-    return out
+    def get_full_sequence(self, file_idx: int = 0):
+        img_np, lat_np = self._load_arrays(file_idx)
+        return (
+            torch.from_numpy(np.asarray(img_np)).float(),
+            torch.from_numpy(np.asarray(lat_np)).float(),
+        )

--- a/train/video2mesh.py
+++ b/train/video2mesh.py
@@ -2,47 +2,55 @@
 ### video2mesh.py ###
 # Training script for the video2mesh temporal DiT (TripoSGDiTModel4D).
 #
-# Assumes the dataset has already been preprocessed with
-# preprocess/preprocess_data.py, which stores per-sample .npz files of
-# (VAE-encoded mesh latent, frozen DinoV2 image embedding) sequences.
-# Training optimises only the transformer using flow matching on the
-# frozen latents — the VAE and image encoder are not needed here.
+# Port of train_s2_0821_ddp.py (LoRA + RectifiedFlow + CFG dropout) into the
+# mocapv2 project style (YAML-driven, shared dist/log utilities).
+#
+# The dataset must already be preprocessed with preprocess/preprocess_data.py,
+# producing per-sample .npz files containing:
+#     image_embed: [T, 257, 1024]   frozen DinoV2 embeddings
+#     latent:      [T, 2048, 64]    VAE-encoded mesh latents
+#
+# Only the transformer is trained here (VAE + image encoder are frozen and
+# already applied during preprocessing).
 
-import os
-import time
-import math
 import argparse
-from typing import Dict, Any, Optional
-
-import numpy as np
-from tqdm import tqdm
+import copy
+import json
+import os
+import re
+from datetime import datetime
+from typing import List, Optional
 
 import torch
-import torch.nn as nn
-import torch.optim as optim
+import torch.distributed as dist
+import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.tensorboard import SummaryWriter
+from tqdm import tqdm
 
-from utils.dist_utils import (
-    setup_distributed,
-    is_main_process,
-    cleanup_distributed,
-    worker_init_fn,
-    reduce_sum_scalar,
-)
-from utils.train_utils import (
-    save_checkpoint_with_epoch,
-    cleanup_old_checkpoints,
-    find_latest_ckpt,
-    load_checkpoint,
-    load_partial_pretrain,
-)
+from data.loader_v1_mesh import FullSequenceLatentDataset
+from models.v1.video2mesh.triposg_transformer import TripoSGDiTModel4D
 from utils.common import set_seed
+from utils.config_utils import load_yaml_config, dump_yaml_config
+from utils.dist_utils import (
+    cleanup_distributed,
+    is_main_process,
+    setup_distributed,
+)
 from utils.logger import logger
-from utils.config_utils import load_yaml_config, dump_yaml_config, instantiate_from_config
 
-from data.loader_v1_mesh import VideoMeshLatentDataset, collate_video_mesh
+# RectifiedFlow scheduler comes from the TripoSG package (same as preprocess/).
+from TripoSG.triposg.schedulers.scheduling_rectified_flow import (
+    RectifiedFlowScheduler,
+    compute_density_for_timestep_sampling,
+    compute_loss_weighting,
+)
+
+try:
+    from diffusers.models.lora import LoRACompatibleLinear
+except Exception:  # diffusers moved this around across versions
+    LoRACompatibleLinear = None
 
 torch.multiprocessing.set_start_method("spawn", force=True)
 
@@ -50,234 +58,182 @@ PROCESS_NAME = "video2mesh"
 
 
 # =========================================================
-# flow-matching helpers
+# checkpoint io
 # =========================================================
-def _sample_flow_matching_t(
-    batch_size: int,
-    device: torch.device,
-    schedule: str = "uniform",
-    logit_normal_mean: float = 0.0,
-    logit_normal_std: float = 1.0,
-) -> torch.Tensor:
-    """
-    Sample flow-matching time parameter u in (0, 1) per sample.
-
-    schedule:
-        uniform       : u ~ U(0, 1)
-        logit_normal  : u = sigmoid(N(mean, std))  (as used in SD3/Flux)
-    """
-    if schedule == "uniform":
-        u = torch.rand(batch_size, device=device)
-    elif schedule == "logit_normal":
-        z = torch.randn(batch_size, device=device) * logit_normal_std + logit_normal_mean
-        u = torch.sigmoid(z)
-    else:
-        raise ValueError(f"Unknown flow matching schedule: {schedule}")
-
-    # Clamp away from endpoints for numerical stability.
-    return u.clamp(1e-5, 1.0 - 1e-5)
+def _find_latest_step_ckpt(root: str) -> Optional[str]:
+    if not os.path.isdir(root):
+        return None
+    max_step = -1
+    latest = None
+    for name in os.listdir(root):
+        m = re.match(r"checkpoint_step_(\d+)", name)
+        if m:
+            step = int(m.group(1))
+            if step > max_step:
+                max_step = step
+                latest = os.path.join(root, name)
+    return latest
 
 
-def compute_flow_matching_loss(
-    transformer: nn.Module,
-    latent: torch.Tensor,           # [B, T, N, D]
-    image_embed: torch.Tensor,      # [B, T, C, D_cond]
-    attention_kwargs: Optional[Dict[str, Any]],
-    t_schedule: str,
-    t_mean: float,
-    t_std: float,
-    timestep_scale: float,
-    loss_type: str = "l2",
-):
-    """
-    Standard rectified-flow / flow-matching loss:
-        x_0 = data (mesh latent)
-        x_1 = noise ~ N(0, I)
-        x_t = (1 - u) x_0 + u x_1
-        target = x_1 - x_0
-        pred   = transformer(x_t, t_model, cond)
-        loss   = || pred - target ||
-    """
-    B = latent.shape[0]
-    device = latent.device
-
-    u = _sample_flow_matching_t(
-        batch_size=B,
-        device=device,
-        schedule=t_schedule,
-        logit_normal_mean=t_mean,
-        logit_normal_std=t_std,
-    )
-    # Broadcast u over [T, N, D] dims.
-    u_b = u.view(B, 1, 1, 1).to(latent.dtype)
-
-    noise = torch.randn_like(latent)
-    x_t = (1.0 - u_b) * latent + u_b * noise
-    target = noise - latent
-
-    # TripoSG expects the timestep in [0, 1000] range (positional embedding).
-    timestep = (u * timestep_scale).to(latent.dtype)
-
-    pred_out = transformer(
-        hidden_states=x_t,
-        timestep=timestep,
-        encoder_hidden_states=image_embed,
-        attention_kwargs=attention_kwargs,
-        return_dict=False,
-    )
-    pred = pred_out[0]
-
-    if loss_type == "l2":
-        per_sample = (pred.float() - target.float()).pow(2).mean(dim=[1, 2, 3])
-    elif loss_type == "l1":
-        per_sample = (pred.float() - target.float()).abs().mean(dim=[1, 2, 3])
-    elif loss_type == "smooth_l1":
-        per_sample = nn.functional.smooth_l1_loss(
-            pred.float(), target.float(), reduction="none"
-        ).mean(dim=[1, 2, 3])
-    else:
-        raise ValueError(f"Unsupported loss_type: {loss_type}")
-
-    loss = per_sample.mean()
-    return loss, {
-        "loss": loss.detach(),
-        "u_mean": u.mean().detach(),
-        "u_std": u.std(unbiased=False).detach() if B > 1 else torch.zeros((), device=device),
-    }
-
-
-# =========================================================
-# dataloaders
-# =========================================================
-def build_dataloaders(data_cfg, train_cfg, eval_cfg, attention_design, distributed, rank, world_size):
-    window = attention_design["seq_len"]
-
-    train_ds = VideoMeshLatentDataset(
-        npz_dir=data_cfg["npz_dir"],
-        window=window,
-        split_json=data_cfg.get("split_json"),
-        split_mode="train",
-        min_frames=data_cfg.get("min_frames"),
-        preload_all=data_cfg.get("preload_all", False),
-        debug_limit=data_cfg.get("debug_limit"),
-    )
-
-    train_sampler = (
-        DistributedSampler(train_ds, num_replicas=world_size, rank=rank, shuffle=True)
-        if distributed else None
-    )
-
-    train_loader = DataLoader(
-        train_ds,
-        batch_size=train_cfg["batch_size"],
-        sampler=train_sampler,
-        shuffle=(train_sampler is None),
-        num_workers=train_cfg.get("num_workers_train", 4),
-        collate_fn=collate_video_mesh,
-        worker_init_fn=worker_init_fn,
-        drop_last=True,
-    )
-
-    eval_ds = VideoMeshLatentDataset(
-        npz_dir=data_cfg["npz_dir"],
-        window=window,
-        split_json=data_cfg.get("split_json"),
-        split_mode="test",
-        min_frames=data_cfg.get("min_frames"),
-        preload_all=data_cfg.get("preload_all", False),
-        debug_limit=data_cfg.get("debug_limit"),
-    )
-
-    if len(eval_ds) == 0:
+def auto_resume_and_load(model, optimizer, output_dir, device, is_lora=False):
+    """Restore the latest checkpoint_step_{N} under ``output_dir``."""
+    ckpt_dir = _find_latest_step_ckpt(output_dir)
+    if ckpt_dir is None:
         if is_main_process():
-            logger.info("[video2mesh] No test split found — evaluation will be skipped.")
-        eval_loader = None
+            logger.info(f"[resume] no checkpoint under {output_dir}, starting from step 0")
+        return 0
+
+    if is_main_process():
+        logger.info(f"[resume] loading {ckpt_dir}")
+
+    adapter_path = os.path.join(ckpt_dir, "adapter_model.safetensors")
+    full_path = os.path.join(ckpt_dir, "diffusion_pytorch_model.safetensors")
+
+    if is_lora and os.path.exists(adapter_path):
+        model.load_adapter(ckpt_dir, "default", is_trainable=True)
+        if is_main_process():
+            logger.info(f"[resume] loaded LoRA adapter from {ckpt_dir}")
+    elif os.path.exists(full_path):
+        from safetensors.torch import load_file
+        device_str = str(device)
+        state_dict = load_file(full_path, device=device_str)
+        model.load_state_dict(state_dict)
+        if is_main_process():
+            logger.info(f"[resume] loaded full transformer weights from {ckpt_dir}")
     else:
-        eval_sampler = (
-            DistributedSampler(eval_ds, num_replicas=world_size, rank=rank, shuffle=False)
-            if distributed else None
-        )
-        eval_loader = DataLoader(
-            eval_ds,
-            batch_size=eval_cfg.get("batch_size", train_cfg["batch_size"]),
-            sampler=eval_sampler,
-            shuffle=False,
-            num_workers=eval_cfg.get("num_workers", 2),
-            collate_fn=collate_video_mesh,
-            worker_init_fn=worker_init_fn,
-            drop_last=False,
-        )
+        raise FileNotFoundError(f"no transformer weights under {ckpt_dir}")
+
+    optimizer_path = os.path.join(ckpt_dir, "optimizer.pt")
+    if os.path.exists(optimizer_path):
+        opt_ckpt = torch.load(optimizer_path, map_location=device)
+        optimizer.load_state_dict(opt_ckpt["optimizer"])
+        step = int(opt_ckpt.get("step", 0))
+        if is_main_process():
+            logger.info(f"[resume] restored optimizer, global_step={step}")
+        return step
 
     if is_main_process():
-        logger.info(f"[video2mesh] train samples: {len(train_ds)}")
-        logger.info(f"[video2mesh] eval  samples: {len(eval_ds)}")
-
-    return train_loader, eval_loader
+        logger.warning(f"[resume] no optimizer.pt in {ckpt_dir}, global_step=0")
+    return 0
 
 
-# =========================================================
-# eval
-# =========================================================
-@torch.no_grad()
-def run_evaluation(
-    loader,
-    transformer,
-    device,
-    attention_design,
-    cfg,
-    writer=None,
-    epoch=None,
-    tag_prefix="test",
-):
-    if loader is None:
-        return {}
-
-    transformer.eval()
-
-    loss_cfg = cfg["train"]["loss"]
-    loss_sum = 0.0
-    sample_count = 0
-
-    tqdm_loader = (
-        tqdm(loader, total=len(loader), desc=f"Eval: {tag_prefix}", ncols=120)
-        if is_main_process() else loader
+def save_checkpoint(model, optimizer, output_dir, global_step):
+    base_model = model.module if hasattr(model, "module") else model
+    step_dir = os.path.join(output_dir, f"checkpoint_step_{global_step}")
+    os.makedirs(step_dir, exist_ok=True)
+    base_model.save_pretrained(step_dir)
+    torch.save(
+        {"optimizer": optimizer.state_dict(), "step": global_step},
+        os.path.join(step_dir, "optimizer.pt"),
     )
+    logger.info(f"[ckpt] saved step {global_step} -> {step_dir}")
+    return step_dir
 
-    cnt = 0
-    for batch in tqdm_loader:
-        cnt += 1
-        if cfg["runtime"]["debug"] and cnt >= 10:
-            break
 
-        latent = batch["latent"].to(device, non_blocking=True)
-        image_embed = batch["image_embed"].to(device, non_blocking=True)
+@torch.inference_mode()
+def merge_lora_to_full_weights_safely(
+    step_dir: str,
+    base_ckpt_dir: str,
+    save_subdir: str = "transformer",
+):
+    """CPU-merge LoRA adapter back into a clean base, save full weights."""
+    from peft import PeftModel
 
-        loss, _ = compute_flow_matching_loss(
-            transformer=transformer,
-            latent=latent,
-            image_embed=image_embed,
-            attention_kwargs=attention_design,
-            t_schedule=loss_cfg.get("t_schedule", "uniform"),
-            t_mean=loss_cfg.get("t_mean", 0.0),
-            t_std=loss_cfg.get("t_std", 1.0),
-            timestep_scale=loss_cfg.get("timestep_scale", 1000.0),
-            loss_type=loss_cfg.get("loss_type", "l2"),
-        )
+    cpu_base = TripoSGDiTModel4D.from_pretrained(
+        base_ckpt_dir, torch_dtype=torch.float32, device_map="cpu"
+    )
+    cpu_peft = PeftModel.from_pretrained(cpu_base, step_dir, is_trainable=False)
+    merged = cpu_peft.merge_and_unload()
+    out_dir = os.path.join(step_dir, save_subdir)
+    os.makedirs(out_dir, exist_ok=True)
+    merged.save_pretrained(out_dir)
+    logger.info(f"[merge] merged LoRA on CPU -> {out_dir}")
 
-        bs = latent.size(0)
-        loss_sum += float(loss.item()) * bs
-        sample_count += bs
 
-    sample_count = reduce_sum_scalar(sample_count, device)
-    loss_sum = reduce_sum_scalar(loss_sum, device) / max(sample_count, 1)
+def cleanup_old_step_ckpts(output_dir: str, max_ckpt: int):
+    if max_ckpt is None or max_ckpt <= 0:
+        return
+    if not os.path.isdir(output_dir):
+        return
+    entries = []
+    for name in os.listdir(output_dir):
+        m = re.match(r"checkpoint_step_(\d+)$", name)
+        if m:
+            entries.append((int(m.group(1)), os.path.join(output_dir, name)))
+    entries.sort()
+    to_delete = entries[: max(0, len(entries) - max_ckpt)]
+    import shutil
+    for step, path in to_delete:
+        try:
+            shutil.rmtree(path)
+            logger.info(f"[ckpt] removed old {path}")
+        except Exception as e:
+            logger.warning(f"[ckpt] failed to remove {path}: {e}")
 
+
+# =========================================================
+# LoRA helpers
+# =========================================================
+def build_lora_target_modules(model, lora_target_mode: str) -> List[str]:
+    """Pick LoRA target module names on the TripoSG DiT blocks."""
+    all_linear_names: List[str] = []
+    for name, module in model.named_modules():
+        is_linear = isinstance(module, torch.nn.Linear)
+        if LoRACompatibleLinear is not None and isinstance(module, LoRACompatibleLinear):
+            is_linear = True
+        if is_linear and "temporal_block" not in name:
+            all_linear_names.append(name)
+
+    final: List[str] = []
+    num_blocks = len(model.blocks)
+    for i in range(num_blocks):
+        for attn_idx in (1, 2):
+            q = f"blocks.{i}.attn{attn_idx}.to_q"
+            k = f"blocks.{i}.attn{attn_idx}.to_k"
+            v = f"blocks.{i}.attn{attn_idx}.to_v"
+            o = f"blocks.{i}.attn{attn_idx}.to_out.0"
+            if q in all_linear_names: final.append(q)
+            if k in all_linear_names: final.append(k)
+            if v in all_linear_names: final.append(v)
+            if lora_target_mode == "all" and o in all_linear_names:
+                final.append(o)
+        if lora_target_mode == "all":
+            ff1 = f"blocks.{i}.ff.net.0.proj"
+            ff2 = f"blocks.{i}.ff.net.2"
+            skip_linear = f"blocks.{i}.skip_linear"
+            if ff1 in all_linear_names: final.append(ff1)
+            if ff2 in all_linear_names: final.append(ff2)
+            if skip_linear in all_linear_names: final.append(skip_linear)
+
+    if lora_target_mode == "all":
+        for extra in ("time_proj.linear_1", "time_proj.linear_2", "proj_in", "proj_out"):
+            if extra in all_linear_names:
+                final.append(extra)
+    return final
+
+
+def wrap_with_lora(model, lora_cfg):
+    from peft import LoraConfig, TaskType, get_peft_model
+
+    for p in model.parameters():
+        p.requires_grad = False
+
+    targets = build_lora_target_modules(model, lora_cfg.get("target_mode", "all"))
     if is_main_process():
-        logger.info(f"[{tag_prefix}] fm_loss={loss_sum:.6f}")
+        logger.info(f"[lora] target modules ({len(targets)}): {targets}")
 
-    if writer is not None and epoch is not None:
-        writer.add_scalar(f"{tag_prefix}/fm_loss", loss_sum, epoch)
-
-    return {"fm_loss": loss_sum}
+    cfg = LoraConfig(
+        r=lora_cfg.get("rank", 4),
+        lora_alpha=lora_cfg.get("alpha", lora_cfg.get("rank", 4)),
+        target_modules=targets,
+        lora_dropout=lora_cfg.get("dropout", 0.0),
+        bias="none",
+        task_type=TaskType.FEATURE_EXTRACTION,
+    )
+    model = get_peft_model(model, cfg)
+    if is_main_process():
+        model.print_trainable_parameters()
+    return model
 
 
 # =========================================================
@@ -291,7 +247,7 @@ def train_video2mesh(cfg):
     model_cfg = cfg["model"]
     data_cfg = cfg["data"]
     train_cfg = cfg["train"]
-    eval_cfg = cfg["eval"]
+    lora_cfg = cfg.get("lora", {"enable": False})
     output_cfg = cfg["output"]
 
     set_seed(runtime_cfg.get("seed", 42))
@@ -302,247 +258,258 @@ def train_video2mesh(cfg):
     if is_main_process():
         dump_yaml_config(cfg, os.path.join(base_dir, "config.yaml"))
 
-    logdir = os.path.join(base_dir, f"logs_{PROCESS_NAME}")
     if is_main_process():
-        logger.info(f"Log directory: {logdir}")
+        run_id = datetime.now().strftime("%Y%m%d-%H%M%S")
+        log_dir = os.path.join(base_dir, "logs", f"run_{run_id}")
+        os.makedirs(log_dir, exist_ok=True)
+        writer = SummaryWriter(log_dir=log_dir)
+        logger.info(f"TensorBoard log dir: {log_dir}")
+    else:
+        writer = None
 
     device_str = runtime_cfg.get("device", "cuda")
     if device_str == "cuda" and torch.cuda.is_available():
         device = torch.device(f"cuda:{local_rank}")
     else:
         device = torch.device("cpu")
-
-    attention_design = model_cfg["attention_kwargs"]
+    if is_main_process():
+        logger.info(f"device: {device}")
 
     # ---- data ----
-    train_loader, eval_loader = build_dataloaders(
-        data_cfg=data_cfg,
-        train_cfg=train_cfg,
-        eval_cfg=eval_cfg,
-        attention_design=attention_design,
-        distributed=distributed,
-        rank=rank,
-        world_size=world_size,
+    seq_len = int(data_cfg["seq_len"])
+    dataset = FullSequenceLatentDataset(
+        npz_dirs=data_cfg["train_dirs"],
+        seq_len=seq_len,
+        frame_step=data_cfg.get("frame_step", 1),
+        hop=data_cfg.get("hop", 1),
+        drop_last=data_cfg.get("drop_last", True),
+        preload=data_cfg.get("preload", False),
+        num_threads=data_cfg.get("num_threads", 32),
+        skip_json=data_cfg.get("skip_json"),
+    )
+    sampler = (
+        DistributedSampler(dataset, num_replicas=world_size, rank=rank, shuffle=True)
+        if distributed else None
+    )
+    dataloader = DataLoader(
+        dataset,
+        batch_size=train_cfg["batch_size"],
+        shuffle=(sampler is None),
+        num_workers=train_cfg.get("num_workers", 4),
+        pin_memory=(device.type == "cuda"),
+        sampler=sampler,
+        drop_last=True,
     )
 
-    # ---- model (transformer only) ----
-    transformer: nn.Module = instantiate_from_config(model_cfg)
+    # ---- model ----
+    if is_main_process():
+        logger.info(f"loading transformer from {model_cfg['pretrained_path']}")
+    model = TripoSGDiTModel4D.from_pretrained(model_cfg["pretrained_path"])
 
-    if train_cfg.get("use_grad_checkpoint", False):
-        if hasattr(transformer, "enable_gradient_checkpointing"):
-            transformer.enable_gradient_checkpointing()
-        else:
-            transformer.gradient_checkpointing = True
+    if train_cfg.get("gradient_checkpointing", False):
+        model.gradient_checkpointing = True
+        if is_main_process():
+            logger.info("gradient checkpointing enabled")
 
-    pretrain_ckpt = train_cfg.get("pretrain_ckpt")
-    if pretrain_ckpt is not None:
-        load_partial_pretrain(transformer, pretrain_ckpt)
+    # ---- LoRA wrap (optional) ----
+    if lora_cfg.get("enable", False):
+        model = wrap_with_lora(model, lora_cfg)
 
-    transformer = transformer.to(device)
+    model.to(device)
 
+    # ---- optimizer ----
+    optimizer = torch.optim.AdamW(
+        (p for p in model.parameters() if p.requires_grad),
+        lr=train_cfg["learning_rate"],
+        betas=tuple(train_cfg.get("betas", (0.9, 0.999))),
+        weight_decay=train_cfg.get("weight_decay", 0.0),
+    )
+
+    global_step = 0
+    if train_cfg.get("resume", False):
+        global_step = auto_resume_and_load(
+            model, optimizer, base_dir, device, is_lora=lora_cfg.get("enable", False)
+        )
+
+    if is_main_process():
+        trainable_count = sum(1 for _, p in model.named_parameters() if p.requires_grad)
+        trainable_num = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        logger.info(f"trainable param tensors: {trainable_count}")
+        logger.info(f"trainable param count:   {trainable_num:,}")
+
+    # ---- AMP ----
+    use_amp = train_cfg.get("use_amp", True) and device.type == "cuda"
+    amp_dtype_str = runtime_cfg.get("amp_dtype", "bfloat16")
+    amp_dtype = {
+        "float16": torch.float16, "fp16": torch.float16,
+        "bfloat16": torch.bfloat16, "bf16": torch.bfloat16,
+    }.get(amp_dtype_str, torch.bfloat16)
+    # GradScaler is only needed for fp16
+    scaler = torch.amp.GradScaler("cuda", enabled=(use_amp and amp_dtype == torch.float16))
+
+    # ---- scheduler ----
+    with open(train_cfg["scheduler_config_path"], "r") as f:
+        sched_config = json.load(f)
+    scheduler = RectifiedFlowScheduler(**sched_config)
+
+    # ---- DDP wrap ----
     if distributed:
-        transformer = torch.nn.parallel.DistributedDataParallel(
-            transformer,
+        model = torch.nn.parallel.DistributedDataParallel(
+            model,
             device_ids=[local_rank],
             output_device=local_rank,
             find_unused_parameters=train_cfg.get("find_unused_parameters", False),
         )
 
-    # ---- optimizer ----
-    lr = train_cfg["lr"]
-    weight_decay = train_cfg.get("weight_decay", 0.0)
-    betas = tuple(train_cfg.get("betas", (0.9, 0.999)))
-
-    if weight_decay == 0.0:
-        optimizer = optim.Adam(transformer.parameters(), lr=lr, betas=betas)
-    else:
-        optimizer = optim.AdamW(
-            transformer.parameters(), lr=lr, betas=betas, weight_decay=weight_decay
-        )
-
-    writer = SummaryWriter(logdir) if is_main_process() else None
+    # ---- attention design ----
+    attention_design = dict(model_cfg["attention_kwargs"])
+    attention_design["seq_len"] = seq_len
 
     if is_main_process():
-        total_params = sum(p.numel() for p in transformer.parameters())
-        trainable = sum(p.numel() for p in transformer.parameters() if p.requires_grad)
-        logger.info("=" * 60)
-        logger.info(f"[{PROCESS_NAME}] total     params: {total_params:,}")
-        logger.info(f"[{PROCESS_NAME}] trainable params: {trainable:,}")
-        logger.info(f"[{PROCESS_NAME}] seq_len: {attention_design['seq_len']}")
-        logger.info(f"[{PROCESS_NAME}] loss cfg: {train_cfg['loss']}")
-        logger.info("=" * 60)
+        logger.info("***** training *****")
+        logger.info(f"  windows: {len(dataset)}")
+        logger.info(f"  epochs : {train_cfg['num_epochs']}")
+        logger.info(f"  bs/gpu : {train_cfg['batch_size']}")
+        logger.info(f"  accum  : {train_cfg.get('gradient_accumulation_steps', 1)}")
+        logger.info(f"  world  : {world_size}")
+        logger.info(f"  attn   : {attention_design}")
 
-    best_test_loss = float("inf")
-    best_ckpt_path = os.path.join(base_dir, f"{PROCESS_NAME}_ckpt_best.pt")
-    start_epoch = 0
-
-    ckpt_path_latest = find_latest_ckpt(base_dir, PROCESS_NAME)
-    if ckpt_path_latest and os.path.exists(ckpt_path_latest):
-        if is_main_process():
-            logger.info(f"Loading checkpoint: {ckpt_path_latest}")
-        start_epoch = load_checkpoint(
-            transformer.module if distributed else transformer,
-            optimizer,
-            ckpt_path_latest,
-            device,
-        )
-        if is_main_process():
-            logger.info(f"Resumed from epoch {start_epoch}")
-
-    amp_dtype_str = runtime_cfg.get("amp_dtype", "float16")
-    amp_dtype = {
-        "float16": torch.float16,
-        "bfloat16": torch.bfloat16,
-        "fp16": torch.float16,
-        "bf16": torch.bfloat16,
-    }.get(amp_dtype_str, torch.float16)
-    use_scaler = amp_dtype == torch.float16
-    scaler = torch.amp.GradScaler("cuda", enabled=use_scaler)
-
-    global_step = 0
-    epochs = train_cfg["epochs"]
-    grad_accum_steps = train_cfg.get("grad_accum_steps", 1)
+    uncond_dropout_prob = train_cfg.get("uncond_dropout_prob", 0.1)
+    t_weighting = train_cfg.get("timestep_sampling_weighting", "logit_normal")
+    loss_weighting_scheme = train_cfg.get("loss_weighting_scheme", "sigma_sqrt")
+    logit_mean = train_cfg.get("logit_mean", 0.0)
+    logit_std = train_cfg.get("logit_std", 1.0)
+    grad_accum = train_cfg.get("gradient_accumulation_steps", 1)
     max_grad_norm = train_cfg.get("max_grad_norm", 1.0)
+    save_every = train_cfg.get("save_every", 0)
+    log_every = train_cfg.get("log_every", 10)
+    max_ckpt = train_cfg.get("max_ckpt", 0)
+    debug = runtime_cfg.get("debug", False)
 
-    for epoch in range(start_epoch, epochs):
-        if distributed and isinstance(train_loader.sampler, DistributedSampler):
-            train_loader.sampler.set_epoch(epoch)
+    model.train()
 
-        transformer.train()
-        running_loss = 0.0
-        seen_samples = 0
-        epoch_start_time = time.time()
+    try:
+        for epoch in range(train_cfg["num_epochs"]):
+            if distributed and sampler is not None:
+                sampler.set_epoch(epoch)
 
-        loader_tqdm = (
-            tqdm(
-                enumerate(train_loader),
-                total=len(train_loader),
-                desc=f"Epoch {epoch + 1}/{epochs} [train][rank{rank}]",
+            progress = tqdm(
+                dataloader,
+                desc=f"Epoch {epoch} (rank {rank})",
+                disable=not is_main_process(),
                 ncols=120,
             )
-            if is_main_process()
-            else enumerate(train_loader)
-        )
 
-        batch_times = []
-        optimizer.zero_grad(set_to_none=True)
+            step_in_epoch = 0
+            for batch in progress:
+                step_in_epoch += 1
+                if debug and step_in_epoch >= 10:
+                    break
 
-        cnt = 0
-        for i, batch in loader_tqdm:
-            cnt += 1
-            if cfg["runtime"]["debug"] and cnt >= 10:
-                break
-            batch_start_time = time.time()
+                image_feat, latent_gt = batch
+                image_feat = image_feat.to(device, non_blocking=True)
+                latent_gt = latent_gt.to(device, non_blocking=True)
+                B, frames = image_feat.shape[:2]
 
-            latent = batch["latent"].to(device, non_blocking=True)
-            image_embed = batch["image_embed"].to(device, non_blocking=True)
+                # CFG unconditional dropout (replace cond with zeros)
+                if uncond_dropout_prob > 0:
+                    uncond_mask = torch.rand(B, device=device) < uncond_dropout_prob
+                    if uncond_mask.any():
+                        image_feat[uncond_mask] = 0.0
 
-            with torch.amp.autocast("cuda", dtype=amp_dtype):
-                raw_loss, loss_info = compute_flow_matching_loss(
-                    transformer=transformer,
-                    latent=latent,
-                    image_embed=image_embed,
-                    attention_kwargs=attention_design,
-                    t_schedule=train_cfg["loss"].get("t_schedule", "uniform"),
-                    t_mean=train_cfg["loss"].get("t_mean", 0.0),
-                    t_std=train_cfg["loss"].get("t_std", 1.0),
-                    timestep_scale=train_cfg["loss"].get("timestep_scale", 1000.0),
-                    loss_type=train_cfg["loss"].get("loss_type", "l2"),
+                # sample timesteps via density from the RF scheduler
+                t_sigmas = compute_density_for_timestep_sampling(
+                    weighting_scheme=t_weighting,
+                    batch_size=B,
+                    logit_mean=logit_mean,
+                    logit_std=logit_std,
+                ).to(device)
+                timesteps = scheduler._sigma_to_t(t_sigmas).long()
+
+                noise = torch.randn_like(latent_gt)
+                noisy_latent = scheduler.scale_noise(
+                    original_samples=latent_gt,
+                    noise=noise,
+                    timesteps=timesteps,
                 )
+                target_velocity = latent_gt - noise
 
-            loss = raw_loss / grad_accum_steps
-            if use_scaler:
-                scaler.scale(loss).backward()
-            else:
-                loss.backward()
+                with torch.amp.autocast("cuda", dtype=amp_dtype, enabled=use_amp):
+                    model_output = model(
+                        hidden_states=noisy_latent,
+                        timestep=timesteps,
+                        encoder_hidden_states=image_feat,
+                        attention_kwargs=attention_design,
+                        return_dict=True,
+                    ).sample
 
-            if (i + 1) % grad_accum_steps == 0 or (i + 1) == len(train_loader):
-                if use_scaler:
-                    scaler.unscale_(optimizer)
-                if max_grad_norm is not None and max_grad_norm > 0:
-                    torch.nn.utils.clip_grad_norm_(transformer.parameters(), max_grad_norm)
-                if use_scaler:
-                    scaler.step(optimizer)
-                    scaler.update()
+                    loss = F.mse_loss(
+                        model_output.float(), target_velocity.float(), reduction="none"
+                    )
+                    loss_weights = compute_loss_weighting(
+                        loss_weighting_scheme, sigmas=t_sigmas
+                    )
+                    loss = (loss * loss_weights.view(B, 1, 1, 1)).mean()
+                    loss = loss / grad_accum
+
+                if scaler.is_enabled():
+                    scaler.scale(loss).backward()
                 else:
-                    optimizer.step()
-                optimizer.zero_grad(set_to_none=True)
+                    loss.backward()
 
-            bs = latent.size(0)
-            running_loss += raw_loss.item() * bs
-            seen_samples += bs
+                if (global_step + 1) % grad_accum == 0:
+                    if scaler.is_enabled():
+                        scaler.unscale_(optimizer)
+                    if max_grad_norm is not None and max_grad_norm > 0:
+                        torch.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)
+                    if scaler.is_enabled():
+                        scaler.step(optimizer)
+                        scaler.update()
+                    else:
+                        optimizer.step()
+                    optimizer.zero_grad(set_to_none=True)
 
-            if writer is not None and global_step % 10 == 0:
-                writer.add_scalar("train/fm_loss", raw_loss.item(), global_step)
-                writer.add_scalar("train/u_mean", float(loss_info["u_mean"].item()), global_step)
-                writer.add_scalar("train/u_std", float(loss_info["u_std"].item()), global_step)
+                global_step += 1
 
-            global_step += 1
+                if is_main_process() and (global_step % log_every == 0):
+                    raw_loss_val = float(loss.item()) * grad_accum
+                    if writer is not None:
+                        writer.add_scalar("Loss/train", raw_loss_val, global_step)
+                        writer.add_scalar(
+                            "LR", optimizer.param_groups[0]["lr"], global_step
+                        )
+                    logger.info(
+                        f"step {global_step} epoch {epoch} loss={raw_loss_val:.4f} "
+                        f"lr={optimizer.param_groups[0]['lr']:.2e}"
+                    )
 
-            batch_time = time.time() - batch_start_time
-            batch_times.append(batch_time)
-            if is_main_process() and i % 10 == 0 and i > 0:
-                avg_batch = sum(batch_times) / len(batch_times)
-                remaining = avg_batch * (len(train_loader) - i - 1)
-                loader_tqdm.set_postfix_str(
-                    f"Loss={raw_loss.item():.4f} | ETA={remaining / 60:.1f}min"
-                )
+                should_save = (save_every > 0) and (global_step % save_every == 0)
+                if should_save and is_main_process():
+                    step_dir = save_checkpoint(model, optimizer, base_dir, global_step)
+                    if lora_cfg.get("enable", False) and lora_cfg.get("merge_on_save", True):
+                        merge_lora_to_full_weights_safely(
+                            step_dir=step_dir,
+                            base_ckpt_dir=model_cfg["pretrained_path"],
+                            save_subdir="transformer",
+                        )
+                    cleanup_old_step_ckpts(base_dir, max_ckpt)
+                if distributed and should_save:
+                    dist.barrier()
 
-        train_loss = running_loss / max(seen_samples, 1)
-        epoch_time = time.time() - epoch_start_time
+                if is_main_process():
+                    progress.set_postfix(
+                        loss=float(loss.item()) * grad_accum,
+                        lr=optimizer.param_groups[0]["lr"],
+                    )
 
         if is_main_process():
-            logger.info(
-                f"Epoch {epoch + 1}: train fm_loss={train_loss:.6f} | time {epoch_time:.1f}s"
-            )
-        if writer is not None:
-            writer.add_scalar("epoch/train_fm_loss", train_loss, epoch + 1)
+            save_checkpoint(model, optimizer, base_dir, global_step)
+            if writer is not None:
+                writer.close()
+            logger.info("training done.")
 
-        # -------- eval + checkpoint --------
-        if (epoch + 1) % train_cfg.get("test_every", 1) == 0 or (epoch + 1) == epochs:
-            eval_metrics = run_evaluation(
-                loader=eval_loader,
-                transformer=transformer,
-                device=device,
-                attention_design=attention_design,
-                cfg=cfg,
-                writer=writer,
-                epoch=epoch + 1,
-                tag_prefix="test",
-            )
-
-            if is_main_process():
-                save_checkpoint_with_epoch(
-                    transformer.module if distributed else transformer,
-                    PROCESS_NAME,
-                    optimizer,
-                    epoch + 1,
-                    base_dir,
-                )
-                cleanup_old_checkpoints(base_dir, PROCESS_NAME, train_cfg.get("max_ckpt", 5))
-
-                best_metric_name = eval_cfg.get("best_metric_name", "fm_loss")
-                score = eval_metrics.get(best_metric_name, train_loss)
-                if score < best_test_loss:
-                    best_test_loss = score
-                    torch.save(
-                        {
-                            "model_state": (transformer.module if distributed else transformer).state_dict(),
-                            "optimizer_state": optimizer.state_dict(),
-                            "epoch": epoch + 1,
-                            "best_test_loss": best_test_loss,
-                            "eval_metrics": eval_metrics,
-                        },
-                        best_ckpt_path,
-                    )
-                    logger.info(
-                        f"New best checkpoint saved: {best_ckpt_path} "
-                        f"({best_metric_name}={best_test_loss:.6f})"
-                    )
-
-    if writer is not None:
-        writer.close()
-    cleanup_distributed()
+    finally:
+        cleanup_distributed()
 
 
 if __name__ == "__main__":

--- a/train/video2mesh.py
+++ b/train/video2mesh.py
@@ -1,0 +1,559 @@
+
+### video2mesh.py ###
+# Training script for the video2mesh temporal DiT (TripoSGDiTModel4D).
+#
+# Assumes the dataset has already been preprocessed with
+# preprocess/preprocess_data.py, which stores per-sample .npz files of
+# (VAE-encoded mesh latent, frozen DinoV2 image embedding) sequences.
+# Training optimises only the transformer using flow matching on the
+# frozen latents — the VAE and image encoder are not needed here.
+
+import os
+import time
+import math
+import argparse
+from typing import Dict, Any, Optional
+
+import numpy as np
+from tqdm import tqdm
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+from torch.utils.tensorboard import SummaryWriter
+
+from utils.dist_utils import (
+    setup_distributed,
+    is_main_process,
+    cleanup_distributed,
+    worker_init_fn,
+    reduce_sum_scalar,
+)
+from utils.train_utils import (
+    save_checkpoint_with_epoch,
+    cleanup_old_checkpoints,
+    find_latest_ckpt,
+    load_checkpoint,
+    load_partial_pretrain,
+)
+from utils.common import set_seed
+from utils.logger import logger
+from utils.config_utils import load_yaml_config, dump_yaml_config, instantiate_from_config
+
+from data.loader_v1_mesh import VideoMeshLatentDataset, collate_video_mesh
+
+torch.multiprocessing.set_start_method("spawn", force=True)
+
+PROCESS_NAME = "video2mesh"
+
+
+# =========================================================
+# flow-matching helpers
+# =========================================================
+def _sample_flow_matching_t(
+    batch_size: int,
+    device: torch.device,
+    schedule: str = "uniform",
+    logit_normal_mean: float = 0.0,
+    logit_normal_std: float = 1.0,
+) -> torch.Tensor:
+    """
+    Sample flow-matching time parameter u in (0, 1) per sample.
+
+    schedule:
+        uniform       : u ~ U(0, 1)
+        logit_normal  : u = sigmoid(N(mean, std))  (as used in SD3/Flux)
+    """
+    if schedule == "uniform":
+        u = torch.rand(batch_size, device=device)
+    elif schedule == "logit_normal":
+        z = torch.randn(batch_size, device=device) * logit_normal_std + logit_normal_mean
+        u = torch.sigmoid(z)
+    else:
+        raise ValueError(f"Unknown flow matching schedule: {schedule}")
+
+    # Clamp away from endpoints for numerical stability.
+    return u.clamp(1e-5, 1.0 - 1e-5)
+
+
+def compute_flow_matching_loss(
+    transformer: nn.Module,
+    latent: torch.Tensor,           # [B, T, N, D]
+    image_embed: torch.Tensor,      # [B, T, C, D_cond]
+    attention_kwargs: Optional[Dict[str, Any]],
+    t_schedule: str,
+    t_mean: float,
+    t_std: float,
+    timestep_scale: float,
+    loss_type: str = "l2",
+):
+    """
+    Standard rectified-flow / flow-matching loss:
+        x_0 = data (mesh latent)
+        x_1 = noise ~ N(0, I)
+        x_t = (1 - u) x_0 + u x_1
+        target = x_1 - x_0
+        pred   = transformer(x_t, t_model, cond)
+        loss   = || pred - target ||
+    """
+    B = latent.shape[0]
+    device = latent.device
+
+    u = _sample_flow_matching_t(
+        batch_size=B,
+        device=device,
+        schedule=t_schedule,
+        logit_normal_mean=t_mean,
+        logit_normal_std=t_std,
+    )
+    # Broadcast u over [T, N, D] dims.
+    u_b = u.view(B, 1, 1, 1).to(latent.dtype)
+
+    noise = torch.randn_like(latent)
+    x_t = (1.0 - u_b) * latent + u_b * noise
+    target = noise - latent
+
+    # TripoSG expects the timestep in [0, 1000] range (positional embedding).
+    timestep = (u * timestep_scale).to(latent.dtype)
+
+    pred_out = transformer(
+        hidden_states=x_t,
+        timestep=timestep,
+        encoder_hidden_states=image_embed,
+        attention_kwargs=attention_kwargs,
+        return_dict=False,
+    )
+    pred = pred_out[0]
+
+    if loss_type == "l2":
+        per_sample = (pred.float() - target.float()).pow(2).mean(dim=[1, 2, 3])
+    elif loss_type == "l1":
+        per_sample = (pred.float() - target.float()).abs().mean(dim=[1, 2, 3])
+    elif loss_type == "smooth_l1":
+        per_sample = nn.functional.smooth_l1_loss(
+            pred.float(), target.float(), reduction="none"
+        ).mean(dim=[1, 2, 3])
+    else:
+        raise ValueError(f"Unsupported loss_type: {loss_type}")
+
+    loss = per_sample.mean()
+    return loss, {
+        "loss": loss.detach(),
+        "u_mean": u.mean().detach(),
+        "u_std": u.std(unbiased=False).detach() if B > 1 else torch.zeros((), device=device),
+    }
+
+
+# =========================================================
+# dataloaders
+# =========================================================
+def build_dataloaders(data_cfg, train_cfg, eval_cfg, attention_design, distributed, rank, world_size):
+    window = attention_design["seq_len"]
+
+    train_ds = VideoMeshLatentDataset(
+        npz_dir=data_cfg["npz_dir"],
+        window=window,
+        split_json=data_cfg.get("split_json"),
+        split_mode="train",
+        min_frames=data_cfg.get("min_frames"),
+        preload_all=data_cfg.get("preload_all", False),
+        debug_limit=data_cfg.get("debug_limit"),
+    )
+
+    train_sampler = (
+        DistributedSampler(train_ds, num_replicas=world_size, rank=rank, shuffle=True)
+        if distributed else None
+    )
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=train_cfg["batch_size"],
+        sampler=train_sampler,
+        shuffle=(train_sampler is None),
+        num_workers=train_cfg.get("num_workers_train", 4),
+        collate_fn=collate_video_mesh,
+        worker_init_fn=worker_init_fn,
+        drop_last=True,
+    )
+
+    eval_ds = VideoMeshLatentDataset(
+        npz_dir=data_cfg["npz_dir"],
+        window=window,
+        split_json=data_cfg.get("split_json"),
+        split_mode="test",
+        min_frames=data_cfg.get("min_frames"),
+        preload_all=data_cfg.get("preload_all", False),
+        debug_limit=data_cfg.get("debug_limit"),
+    )
+
+    if len(eval_ds) == 0:
+        if is_main_process():
+            logger.info("[video2mesh] No test split found — evaluation will be skipped.")
+        eval_loader = None
+    else:
+        eval_sampler = (
+            DistributedSampler(eval_ds, num_replicas=world_size, rank=rank, shuffle=False)
+            if distributed else None
+        )
+        eval_loader = DataLoader(
+            eval_ds,
+            batch_size=eval_cfg.get("batch_size", train_cfg["batch_size"]),
+            sampler=eval_sampler,
+            shuffle=False,
+            num_workers=eval_cfg.get("num_workers", 2),
+            collate_fn=collate_video_mesh,
+            worker_init_fn=worker_init_fn,
+            drop_last=False,
+        )
+
+    if is_main_process():
+        logger.info(f"[video2mesh] train samples: {len(train_ds)}")
+        logger.info(f"[video2mesh] eval  samples: {len(eval_ds)}")
+
+    return train_loader, eval_loader
+
+
+# =========================================================
+# eval
+# =========================================================
+@torch.no_grad()
+def run_evaluation(
+    loader,
+    transformer,
+    device,
+    attention_design,
+    cfg,
+    writer=None,
+    epoch=None,
+    tag_prefix="test",
+):
+    if loader is None:
+        return {}
+
+    transformer.eval()
+
+    loss_cfg = cfg["train"]["loss"]
+    loss_sum = 0.0
+    sample_count = 0
+
+    tqdm_loader = (
+        tqdm(loader, total=len(loader), desc=f"Eval: {tag_prefix}", ncols=120)
+        if is_main_process() else loader
+    )
+
+    cnt = 0
+    for batch in tqdm_loader:
+        cnt += 1
+        if cfg["runtime"]["debug"] and cnt >= 10:
+            break
+
+        latent = batch["latent"].to(device, non_blocking=True)
+        image_embed = batch["image_embed"].to(device, non_blocking=True)
+
+        loss, _ = compute_flow_matching_loss(
+            transformer=transformer,
+            latent=latent,
+            image_embed=image_embed,
+            attention_kwargs=attention_design,
+            t_schedule=loss_cfg.get("t_schedule", "uniform"),
+            t_mean=loss_cfg.get("t_mean", 0.0),
+            t_std=loss_cfg.get("t_std", 1.0),
+            timestep_scale=loss_cfg.get("timestep_scale", 1000.0),
+            loss_type=loss_cfg.get("loss_type", "l2"),
+        )
+
+        bs = latent.size(0)
+        loss_sum += float(loss.item()) * bs
+        sample_count += bs
+
+    sample_count = reduce_sum_scalar(sample_count, device)
+    loss_sum = reduce_sum_scalar(loss_sum, device) / max(sample_count, 1)
+
+    if is_main_process():
+        logger.info(f"[{tag_prefix}] fm_loss={loss_sum:.6f}")
+
+    if writer is not None and epoch is not None:
+        writer.add_scalar(f"{tag_prefix}/fm_loss", loss_sum, epoch)
+
+    return {"fm_loss": loss_sum}
+
+
+# =========================================================
+# main
+# =========================================================
+def train_video2mesh(cfg):
+    distributed, rank, world_size, local_rank = setup_distributed()
+
+    runtime_cfg = cfg["runtime"]
+    exp_cfg = cfg["experiment"]
+    model_cfg = cfg["model"]
+    data_cfg = cfg["data"]
+    train_cfg = cfg["train"]
+    eval_cfg = cfg["eval"]
+    output_cfg = cfg["output"]
+
+    set_seed(runtime_cfg.get("seed", 42))
+
+    base_dir = os.path.join(output_cfg["checkpoint_root"], exp_cfg["exp"])
+    os.makedirs(base_dir, exist_ok=True)
+
+    if is_main_process():
+        dump_yaml_config(cfg, os.path.join(base_dir, "config.yaml"))
+
+    logdir = os.path.join(base_dir, f"logs_{PROCESS_NAME}")
+    if is_main_process():
+        logger.info(f"Log directory: {logdir}")
+
+    device_str = runtime_cfg.get("device", "cuda")
+    if device_str == "cuda" and torch.cuda.is_available():
+        device = torch.device(f"cuda:{local_rank}")
+    else:
+        device = torch.device("cpu")
+
+    attention_design = model_cfg["attention_kwargs"]
+
+    # ---- data ----
+    train_loader, eval_loader = build_dataloaders(
+        data_cfg=data_cfg,
+        train_cfg=train_cfg,
+        eval_cfg=eval_cfg,
+        attention_design=attention_design,
+        distributed=distributed,
+        rank=rank,
+        world_size=world_size,
+    )
+
+    # ---- model (transformer only) ----
+    transformer: nn.Module = instantiate_from_config(model_cfg)
+
+    if train_cfg.get("use_grad_checkpoint", False):
+        if hasattr(transformer, "enable_gradient_checkpointing"):
+            transformer.enable_gradient_checkpointing()
+        else:
+            transformer.gradient_checkpointing = True
+
+    pretrain_ckpt = train_cfg.get("pretrain_ckpt")
+    if pretrain_ckpt is not None:
+        load_partial_pretrain(transformer, pretrain_ckpt)
+
+    transformer = transformer.to(device)
+
+    if distributed:
+        transformer = torch.nn.parallel.DistributedDataParallel(
+            transformer,
+            device_ids=[local_rank],
+            output_device=local_rank,
+            find_unused_parameters=train_cfg.get("find_unused_parameters", False),
+        )
+
+    # ---- optimizer ----
+    lr = train_cfg["lr"]
+    weight_decay = train_cfg.get("weight_decay", 0.0)
+    betas = tuple(train_cfg.get("betas", (0.9, 0.999)))
+
+    if weight_decay == 0.0:
+        optimizer = optim.Adam(transformer.parameters(), lr=lr, betas=betas)
+    else:
+        optimizer = optim.AdamW(
+            transformer.parameters(), lr=lr, betas=betas, weight_decay=weight_decay
+        )
+
+    writer = SummaryWriter(logdir) if is_main_process() else None
+
+    if is_main_process():
+        total_params = sum(p.numel() for p in transformer.parameters())
+        trainable = sum(p.numel() for p in transformer.parameters() if p.requires_grad)
+        logger.info("=" * 60)
+        logger.info(f"[{PROCESS_NAME}] total     params: {total_params:,}")
+        logger.info(f"[{PROCESS_NAME}] trainable params: {trainable:,}")
+        logger.info(f"[{PROCESS_NAME}] seq_len: {attention_design['seq_len']}")
+        logger.info(f"[{PROCESS_NAME}] loss cfg: {train_cfg['loss']}")
+        logger.info("=" * 60)
+
+    best_test_loss = float("inf")
+    best_ckpt_path = os.path.join(base_dir, f"{PROCESS_NAME}_ckpt_best.pt")
+    start_epoch = 0
+
+    ckpt_path_latest = find_latest_ckpt(base_dir, PROCESS_NAME)
+    if ckpt_path_latest and os.path.exists(ckpt_path_latest):
+        if is_main_process():
+            logger.info(f"Loading checkpoint: {ckpt_path_latest}")
+        start_epoch = load_checkpoint(
+            transformer.module if distributed else transformer,
+            optimizer,
+            ckpt_path_latest,
+            device,
+        )
+        if is_main_process():
+            logger.info(f"Resumed from epoch {start_epoch}")
+
+    amp_dtype_str = runtime_cfg.get("amp_dtype", "float16")
+    amp_dtype = {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }.get(amp_dtype_str, torch.float16)
+    use_scaler = amp_dtype == torch.float16
+    scaler = torch.amp.GradScaler("cuda", enabled=use_scaler)
+
+    global_step = 0
+    epochs = train_cfg["epochs"]
+    grad_accum_steps = train_cfg.get("grad_accum_steps", 1)
+    max_grad_norm = train_cfg.get("max_grad_norm", 1.0)
+
+    for epoch in range(start_epoch, epochs):
+        if distributed and isinstance(train_loader.sampler, DistributedSampler):
+            train_loader.sampler.set_epoch(epoch)
+
+        transformer.train()
+        running_loss = 0.0
+        seen_samples = 0
+        epoch_start_time = time.time()
+
+        loader_tqdm = (
+            tqdm(
+                enumerate(train_loader),
+                total=len(train_loader),
+                desc=f"Epoch {epoch + 1}/{epochs} [train][rank{rank}]",
+                ncols=120,
+            )
+            if is_main_process()
+            else enumerate(train_loader)
+        )
+
+        batch_times = []
+        optimizer.zero_grad(set_to_none=True)
+
+        cnt = 0
+        for i, batch in loader_tqdm:
+            cnt += 1
+            if cfg["runtime"]["debug"] and cnt >= 10:
+                break
+            batch_start_time = time.time()
+
+            latent = batch["latent"].to(device, non_blocking=True)
+            image_embed = batch["image_embed"].to(device, non_blocking=True)
+
+            with torch.amp.autocast("cuda", dtype=amp_dtype):
+                raw_loss, loss_info = compute_flow_matching_loss(
+                    transformer=transformer,
+                    latent=latent,
+                    image_embed=image_embed,
+                    attention_kwargs=attention_design,
+                    t_schedule=train_cfg["loss"].get("t_schedule", "uniform"),
+                    t_mean=train_cfg["loss"].get("t_mean", 0.0),
+                    t_std=train_cfg["loss"].get("t_std", 1.0),
+                    timestep_scale=train_cfg["loss"].get("timestep_scale", 1000.0),
+                    loss_type=train_cfg["loss"].get("loss_type", "l2"),
+                )
+
+            loss = raw_loss / grad_accum_steps
+            if use_scaler:
+                scaler.scale(loss).backward()
+            else:
+                loss.backward()
+
+            if (i + 1) % grad_accum_steps == 0 or (i + 1) == len(train_loader):
+                if use_scaler:
+                    scaler.unscale_(optimizer)
+                if max_grad_norm is not None and max_grad_norm > 0:
+                    torch.nn.utils.clip_grad_norm_(transformer.parameters(), max_grad_norm)
+                if use_scaler:
+                    scaler.step(optimizer)
+                    scaler.update()
+                else:
+                    optimizer.step()
+                optimizer.zero_grad(set_to_none=True)
+
+            bs = latent.size(0)
+            running_loss += raw_loss.item() * bs
+            seen_samples += bs
+
+            if writer is not None and global_step % 10 == 0:
+                writer.add_scalar("train/fm_loss", raw_loss.item(), global_step)
+                writer.add_scalar("train/u_mean", float(loss_info["u_mean"].item()), global_step)
+                writer.add_scalar("train/u_std", float(loss_info["u_std"].item()), global_step)
+
+            global_step += 1
+
+            batch_time = time.time() - batch_start_time
+            batch_times.append(batch_time)
+            if is_main_process() and i % 10 == 0 and i > 0:
+                avg_batch = sum(batch_times) / len(batch_times)
+                remaining = avg_batch * (len(train_loader) - i - 1)
+                loader_tqdm.set_postfix_str(
+                    f"Loss={raw_loss.item():.4f} | ETA={remaining / 60:.1f}min"
+                )
+
+        train_loss = running_loss / max(seen_samples, 1)
+        epoch_time = time.time() - epoch_start_time
+
+        if is_main_process():
+            logger.info(
+                f"Epoch {epoch + 1}: train fm_loss={train_loss:.6f} | time {epoch_time:.1f}s"
+            )
+        if writer is not None:
+            writer.add_scalar("epoch/train_fm_loss", train_loss, epoch + 1)
+
+        # -------- eval + checkpoint --------
+        if (epoch + 1) % train_cfg.get("test_every", 1) == 0 or (epoch + 1) == epochs:
+            eval_metrics = run_evaluation(
+                loader=eval_loader,
+                transformer=transformer,
+                device=device,
+                attention_design=attention_design,
+                cfg=cfg,
+                writer=writer,
+                epoch=epoch + 1,
+                tag_prefix="test",
+            )
+
+            if is_main_process():
+                save_checkpoint_with_epoch(
+                    transformer.module if distributed else transformer,
+                    PROCESS_NAME,
+                    optimizer,
+                    epoch + 1,
+                    base_dir,
+                )
+                cleanup_old_checkpoints(base_dir, PROCESS_NAME, train_cfg.get("max_ckpt", 5))
+
+                best_metric_name = eval_cfg.get("best_metric_name", "fm_loss")
+                score = eval_metrics.get(best_metric_name, train_loss)
+                if score < best_test_loss:
+                    best_test_loss = score
+                    torch.save(
+                        {
+                            "model_state": (transformer.module if distributed else transformer).state_dict(),
+                            "optimizer_state": optimizer.state_dict(),
+                            "epoch": epoch + 1,
+                            "best_test_loss": best_test_loss,
+                            "eval_metrics": eval_metrics,
+                        },
+                        best_ckpt_path,
+                    )
+                    logger.info(
+                        f"New best checkpoint saved: {best_ckpt_path} "
+                        f"({best_metric_name}={best_test_loss:.6f})"
+                    )
+
+    if writer is not None:
+        writer.close()
+    cleanup_distributed()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Training script for Video2Mesh (TripoSG temporal DiT)")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="configs/train_video2mesh.yaml",
+        help="Path to the YAML config file",
+    )
+    args = parser.parse_args()
+
+    cfg = load_yaml_config(args.config)
+    train_video2mesh(cfg)

--- a/train/video2pose2rot.py
+++ b/train/video2pose2rot.py
@@ -1,6 +1,5 @@
 
 ### video2pose2rot.py ###
-from train.pose2rot import PROCESS_NAME
 from utils.dist_utils import setup_distributed, is_main_process, cleanup_distributed
 import os
 import sys
@@ -12,7 +11,7 @@ from tqdm import tqdm
 import torch
 import torch.nn as nn
 import torch.optim as optim
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, ConcatDataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.tensorboard import SummaryWriter
 from data.loader_v2 import AnySpeciesPoseDataset, collate_anyspecies_padded
@@ -26,7 +25,6 @@ from utils.train_utils import *
 from utils.config_utils import load_yaml_config, dump_yaml_config
 import argparse
 torch.multiprocessing.set_start_method("spawn", force=True)
-from .video2pose import build_test_dataloaders
 import math
 
 PROCESS_NAME = "video2pose2rot"
@@ -193,6 +191,122 @@ def visualize_joint_sample(
     convert_npy_to_bvh(rot_pred_path, species_name)
     convert_npy_to_bvh(rot_gt_path, species_name)
 
+
+# =========================================================
+# multi-dataset builders
+# =========================================================
+def _normalize_dataset_cfgs(data_cfg):
+    """
+    Accept both legacy single-dataset data config (with bvh_dir/split_json at top level)
+    and the new list form (data.datasets: [...]). Returns a list of per-dataset dicts.
+    """
+    if "datasets" in data_cfg and data_cfg["datasets"]:
+        return list(data_cfg["datasets"])
+
+    # Legacy single-dataset fallback
+    legacy = {
+        "name": data_cfg.get("name", "default"),
+        "bvh_dir": data_cfg["bvh_dir"],
+        "split_json": data_cfg["split_json"],
+        "train_memory_pkl_path": data_cfg.get("train_memory_pkl_path"),
+        "test_memory_pkl_path": data_cfg.get("test_memory_pkl_path"),
+        "test_splits": data_cfg.get("test_splits", ["seen", "rare", "unseen"]),
+    }
+    return [legacy]
+
+
+def build_train_dataset(data_cfg, attention_design):
+    """Build a ConcatDataset from all training datasets in the list."""
+    dataset_cfgs = _normalize_dataset_cfgs(data_cfg)
+
+    train_datasets = []
+    for ds_cfg in dataset_cfgs:
+        ds = AnySpeciesPoseDataset(
+            bvh_dir=ds_cfg["bvh_dir"],
+            window=attention_design["seq_len"],
+            mmap=data_cfg.get("mmap", True),
+            cache_scale=data_cfg.get("cache_scale", True),
+            limit_species_debug=data_cfg.get("limit_species_debug", []),
+            split_json=ds_cfg["split_json"],
+            split_mode="train",
+            memory_pkl_path=ds_cfg.get("train_memory_pkl_path"),
+            preload_all=data_cfg.get("preload_all", False),
+        )
+        if is_main_process():
+            logger.info(
+                f"[train-data] dataset={ds_cfg['name']} "
+                f"bvh_dir={ds_cfg['bvh_dir']} size={len(ds)}"
+            )
+        train_datasets.append(ds)
+
+    if len(train_datasets) == 1:
+        return train_datasets[0]
+    return ConcatDataset(train_datasets)
+
+
+def build_test_dataloaders_multi(
+    data_cfg,
+    eval_cfg,
+    attention_design,
+    distributed,
+    rank,
+    world_size,
+):
+    """
+    Build per-dataset, per-split test loaders.
+    Returns:
+        test_loaders: {dataset_name: {split: DataLoader}}
+    """
+    dataset_cfgs = _normalize_dataset_cfgs(data_cfg)
+    default_splits = eval_cfg.get("split_groups", ["seen", "rare", "unseen"])
+
+    test_loaders = {}
+
+    for ds_cfg in dataset_cfgs:
+        name = ds_cfg["name"]
+        splits = ds_cfg.get("test_splits", default_splits)
+        test_loaders[name] = {}
+
+        for split in splits:
+            ds = AnySpeciesPoseDataset(
+                bvh_dir=ds_cfg["bvh_dir"],
+                window=attention_design["seq_len"],
+                mmap=data_cfg.get("mmap", True),
+                cache_scale=data_cfg.get("cache_scale", True),
+                limit_species_debug=data_cfg.get("limit_species_debug", []),
+                split_json=ds_cfg["split_json"],
+                split_mode="test",
+                split_group=split,
+                memory_pkl_path=ds_cfg.get("test_memory_pkl_path"),
+                preload_all=eval_cfg.get("preload_all", False),
+            )
+
+            sampler = (
+                DistributedSampler(ds, num_replicas=world_size, rank=rank, shuffle=False)
+                if distributed else None
+            )
+
+            loader = DataLoader(
+                ds,
+                batch_size=eval_cfg.get("batch_size", 1),
+                sampler=sampler,
+                shuffle=False,
+                num_workers=eval_cfg.get("num_workers", 2),
+                collate_fn=collate_anyspecies_padded,
+                worker_init_fn=worker_init_fn,
+            )
+
+            if is_main_process():
+                logger.info(
+                    f"[test-data] dataset={name} split={split} "
+                    f"bvh_dir={ds_cfg['bvh_dir']} size={len(ds)}"
+                )
+
+            test_loaders[name][split] = loader
+
+    return test_loaders
+
+
 # =========================================================
 # eval
 # =========================================================
@@ -236,12 +350,12 @@ def run_evaluation(
     vis_done_species = set()
     max_vis_species = 50
 
-    vis_save_dir = os.path.join(base_dir, f"vis_video2pose2rot_epoch{epoch}")
+    vis_save_dir = os.path.join(base_dir, f"vis_video2pose2rot_epoch{epoch}", tag_prefix)
     if is_main_process() and (epoch + 1) % cfg["train"]["vis_every"] == 0:
         os.makedirs(vis_save_dir, exist_ok=True)
 
     with torch.no_grad():
-        
+
         cnt = 0
         for batch in tqdm_loader:
             cnt += 1
@@ -265,7 +379,7 @@ def run_evaluation(
             for k in metric_sums:
                 metric_sums[k] += float(metrics[k]) * bs
 
-            
+
             if is_main_process() and (epoch + 1) % cfg["train"]["vis_every"] == 0:
                 species_list = batch["species"]
                 for si, species_name in enumerate(species_list):
@@ -296,14 +410,14 @@ def run_evaluation(
                         print(f"[VIS] failed on {species_name}: {e}")
 
     sample_count = reduce_sum_scalar(sample_count, device)
-    
+
     for k in metric_sums:
         metric_sums[k] = reduce_sum_scalar(metric_sums[k], device) / max(sample_count, 1)
-            
-    
+
+
     if is_main_process():
         print(
-            f"[Eval] "
+            f"[{tag_prefix}] "
             f"pose_l1={metric_sums['pose_l1']:.6f}, "
             f"pose_l2={metric_sums['pose_l2']:.6f}, "
             f"pose_mpjpe={metric_sums['pose_mpjpe']:.6f}, "
@@ -335,17 +449,17 @@ def train_video2pose2rot(cfg):
     train_cfg = cfg["train"]
     eval_cfg = cfg["eval"]
     output_cfg = cfg["output"]
-    
+
     set_seed(runtime_cfg.get("seed", 42))
 
     base_dir = os.path.join(output_cfg["checkpoint_root"], exp_cfg["exp"])
     os.makedirs(base_dir, exist_ok=True)
-    
+
     # Copy config to checkpoint dir for record
     if is_main_process():
         config_save_path = os.path.join(base_dir, "config.yaml")
         dump_yaml_config(cfg, config_save_path)
-    
+
     logdir = os.path.join(base_dir, "logs_video2pose2rot")
 
     if is_main_process():
@@ -356,20 +470,11 @@ def train_video2pose2rot(cfg):
         device = torch.device(f"cuda:{local_rank}")
     else:
         device = torch.device("cpu")
-        
+
     attention_design = model_cfg["attention_kwargs"]
 
-    dataset_train = AnySpeciesPoseDataset(
-        bvh_dir=data_cfg["bvh_dir"],
-        window=attention_design["seq_len"],
-        mmap=data_cfg.get("mmap", True),
-        cache_scale=data_cfg.get("cache_scale", True),
-        limit_species_debug=data_cfg.get("limit_species_debug", []),
-        split_json=data_cfg["split_json"],
-        split_mode="train",
-        memory_pkl_path=data_cfg["train_memory_pkl_path"],
-        preload_all=data_cfg.get("preload_all", False)
-    )
+    # ---- train data: ConcatDataset across all datasets in the list ----
+    dataset_train = build_train_dataset(data_cfg, attention_design)
 
     sampler_train = (
         DistributedSampler(dataset_train, num_replicas=world_size, rank=rank, shuffle=True)
@@ -386,7 +491,8 @@ def train_video2pose2rot(cfg):
         worker_init_fn=worker_init_fn,
     )
 
-    _, test_loaders = build_test_dataloaders(
+    # ---- test loaders: {dataset_name: {split: loader}} ----
+    test_loaders = build_test_dataloaders_multi(
         data_cfg=data_cfg,
         eval_cfg=eval_cfg,
         attention_design=attention_design,
@@ -394,7 +500,7 @@ def train_video2pose2rot(cfg):
         rank=rank,
         world_size=world_size,
     )
-    
+
     model: torch.nn.Module = instantiate_from_config(model_cfg)
     model = model.to(device)
 
@@ -405,7 +511,7 @@ def train_video2pose2rot(cfg):
             output_device=local_rank,
             find_unused_parameters=True,
         )
-    
+
     lr = train_cfg["lr"]
     weight_decay = train_cfg.get("weight_decay", 0.0)
 
@@ -413,7 +519,7 @@ def train_video2pose2rot(cfg):
         optimizer = optim.Adam(model.parameters(), lr=lr)
     else:
         optimizer = optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
-        
+
     pose_fn = get_loss_fn(train_cfg["loss"].get("pose_loss_type", "smooth_l1"))
     pose_vel_fn = get_loss_fn(train_cfg["loss"].get("pose_vel_loss_type", "smooth_l1"))
     rot_fn = get_loss_fn(train_cfg["loss"].get("rot_loss_type", "smooth_l1"))
@@ -463,9 +569,18 @@ def train_video2pose2rot(cfg):
     global_step = 0
     epochs = train_cfg["epochs"]
     grad_accum_steps = train_cfg.get("grad_accum_steps", 1)
-    
-    split_groups = eval_cfg.get("split_groups", ["seen", "rare", "unseen"])
-    
+
+    # Pick which (dataset, split, metric) drives best-checkpoint selection.
+    # Falls back to the first dataset's first split if not explicitly set.
+    dataset_cfgs = _normalize_dataset_cfgs(data_cfg)
+    default_best_dataset = dataset_cfgs[0]["name"]
+    default_best_split = (
+        dataset_cfgs[0].get("test_splits") or eval_cfg.get("split_groups", ["seen"])
+    )[0]
+    best_metric_dataset = eval_cfg.get("best_metric_dataset", default_best_dataset)
+    best_metric_split = eval_cfg.get("best_metric_split", default_best_split)
+    best_metric_name = eval_cfg.get("best_metric_name", "rot_l1")
+
     for epoch in range(start_epoch, epochs):
         if distributed and isinstance(train_loader.sampler, DistributedSampler):
             train_loader.sampler.set_epoch(epoch)
@@ -580,23 +695,26 @@ def train_video2pose2rot(cfg):
             writer.add_scalar("epoch/pose_pred_prob", pose_pred_prob, epoch + 1)
 
         if (epoch + 1) % train_cfg["test_every"] == 0 or (epoch + 1) == train_cfg["epochs"]:
-            split_metrics = {}
-            for split in split_groups:
-                loader = test_loaders[split]
-                tag_prefix = f"test_{split}"
-                metrics = run_evaluation(
-                    loader=loader,
-                    model=model,
-                    device=device,
-                    attention_design=attention_design,
-                    cfg=cfg,
-                    pose_pred_prob=pose_pred_prob,
-                    writer=writer,
-                    epoch=epoch + 1,
-                    tag_prefix=tag_prefix,
-                    base_dir=base_dir,
-                )
-                split_metrics[split] = metrics
+            # Evaluate on every (dataset, split) pair.
+            # Result shape: {dataset_name: {split: metrics_dict}}
+            all_metrics = {}
+            for ds_name, split_loader_dict in test_loaders.items():
+                all_metrics[ds_name] = {}
+                for split, loader in split_loader_dict.items():
+                    tag_prefix = f"test_{ds_name}_{split}"
+                    metrics = run_evaluation(
+                        loader=loader,
+                        model=model,
+                        device=device,
+                        attention_design=attention_design,
+                        cfg=cfg,
+                        pose_pred_prob=pose_pred_prob,
+                        writer=writer,
+                        epoch=epoch + 1,
+                        tag_prefix=tag_prefix,
+                        base_dir=base_dir,
+                    )
+                    all_metrics[ds_name][split] = metrics
 
             if is_main_process():
                 save_checkpoint_with_epoch(
@@ -608,19 +726,32 @@ def train_video2pose2rot(cfg):
                 )
                 cleanup_old_checkpoints(base_dir, PROCESS_NAME, train_cfg.get("max_ckpt", 100))
 
-                best_metric_split = eval_cfg.get("best_metric_split", "seen")
-                best_metric_name = eval_cfg.get("best_metric_name", "rot_l1")
-                score = split_metrics[best_metric_split][best_metric_name]
-                if score < best_test_loss:
-                    best_test_loss = score
-                    torch.save({
-                        "model_state": (model.module if distributed else model).state_dict(),
-                        "optimizer_state": optimizer.state_dict(),
-                        "epoch": epoch + 1,
-                        "best_test_loss": best_test_loss,
-                        "split_metrics": split_metrics,
-                    }, best_ckpt_path)
-                    print(f"New best checkpoint saved: {best_ckpt_path} ({best_metric_split}/{best_metric_name}={best_test_loss:.6f})")
+                if (
+                    best_metric_dataset in all_metrics
+                    and best_metric_split in all_metrics[best_metric_dataset]
+                    and best_metric_name in all_metrics[best_metric_dataset][best_metric_split]
+                ):
+                    score = all_metrics[best_metric_dataset][best_metric_split][best_metric_name]
+                    if score < best_test_loss:
+                        best_test_loss = score
+                        torch.save({
+                            "model_state": (model.module if distributed else model).state_dict(),
+                            "optimizer_state": optimizer.state_dict(),
+                            "epoch": epoch + 1,
+                            "best_test_loss": best_test_loss,
+                            "all_metrics": all_metrics,
+                        }, best_ckpt_path)
+                        print(
+                            f"New best checkpoint saved: {best_ckpt_path} "
+                            f"({best_metric_dataset}/{best_metric_split}/{best_metric_name}"
+                            f"={best_test_loss:.6f})"
+                        )
+                else:
+                    logger.warning(
+                        f"best_metric tuple "
+                        f"({best_metric_dataset}/{best_metric_split}/{best_metric_name}) "
+                        f"not found in eval results; skipping best-ckpt update."
+                    )
 
     if writer is not None:
         writer.close()

--- a/train/video2pose2rot_v2pv3.py
+++ b/train/video2pose2rot_v2pv3.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 import torch
 import torch.nn as nn
 import torch.optim as optim
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, ConcatDataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.tensorboard import SummaryWriter
 from data.loader_v2 import AnySpeciesPoseDataset, collate_anyspecies_padded
@@ -31,7 +31,6 @@ from utils.config_utils import load_yaml_config, dump_yaml_config
 from utils.logger import logger
 import argparse
 torch.multiprocessing.set_start_method("spawn", force=True)
-from train.video2pose_v3 import build_test_dataloaders
 import math
 
 PROCESS_NAME = "video2pose2rot_v2pv3"
@@ -198,6 +197,122 @@ def visualize_joint_sample(
     convert_npy_to_bvh(rot_pred_path, species_name)
     convert_npy_to_bvh(rot_gt_path, species_name)
 
+
+# =========================================================
+# multi-dataset builders
+# =========================================================
+def _normalize_dataset_cfgs(data_cfg):
+    """
+    Accept both legacy single-dataset data config (with bvh_dir/split_json at top level)
+    and the new list form (data.datasets: [...]). Returns a list of per-dataset dicts.
+    """
+    if "datasets" in data_cfg and data_cfg["datasets"]:
+        return list(data_cfg["datasets"])
+
+    # Legacy single-dataset fallback
+    legacy = {
+        "name": data_cfg.get("name", "default"),
+        "bvh_dir": data_cfg["bvh_dir"],
+        "split_json": data_cfg["split_json"],
+        "train_memory_pkl_path": data_cfg.get("train_memory_pkl_path"),
+        "test_memory_pkl_path": data_cfg.get("test_memory_pkl_path"),
+        "test_splits": data_cfg.get("test_splits", ["seen", "rare", "unseen"]),
+    }
+    return [legacy]
+
+
+def build_train_dataset(data_cfg, attention_design):
+    """Build a ConcatDataset from all training datasets in the list."""
+    dataset_cfgs = _normalize_dataset_cfgs(data_cfg)
+
+    train_datasets = []
+    for ds_cfg in dataset_cfgs:
+        ds = AnySpeciesPoseDataset(
+            bvh_dir=ds_cfg["bvh_dir"],
+            window=attention_design["seq_len"],
+            mmap=data_cfg.get("mmap", True),
+            cache_scale=data_cfg.get("cache_scale", True),
+            limit_species_debug=data_cfg.get("limit_species_debug", []),
+            split_json=ds_cfg["split_json"],
+            split_mode="train",
+            memory_pkl_path=ds_cfg.get("train_memory_pkl_path"),
+            preload_all=data_cfg.get("preload_all", False),
+        )
+        if is_main_process():
+            logger.info(
+                f"[train-data] dataset={ds_cfg['name']} "
+                f"bvh_dir={ds_cfg['bvh_dir']} size={len(ds)}"
+            )
+        train_datasets.append(ds)
+
+    if len(train_datasets) == 1:
+        return train_datasets[0]
+    return ConcatDataset(train_datasets)
+
+
+def build_test_dataloaders_multi(
+    data_cfg,
+    eval_cfg,
+    attention_design,
+    distributed,
+    rank,
+    world_size,
+):
+    """
+    Build per-dataset, per-split test loaders.
+    Returns:
+        test_loaders: {dataset_name: {split: DataLoader}}
+    """
+    dataset_cfgs = _normalize_dataset_cfgs(data_cfg)
+    default_splits = eval_cfg.get("split_groups", ["seen", "rare", "unseen"])
+
+    test_loaders = {}
+
+    for ds_cfg in dataset_cfgs:
+        name = ds_cfg["name"]
+        splits = ds_cfg.get("test_splits", default_splits)
+        test_loaders[name] = {}
+
+        for split in splits:
+            ds = AnySpeciesPoseDataset(
+                bvh_dir=ds_cfg["bvh_dir"],
+                window=attention_design["seq_len"],
+                mmap=data_cfg.get("mmap", True),
+                cache_scale=data_cfg.get("cache_scale", True),
+                limit_species_debug=data_cfg.get("limit_species_debug", []),
+                split_json=ds_cfg["split_json"],
+                split_mode="test",
+                split_group=split,
+                memory_pkl_path=ds_cfg.get("test_memory_pkl_path"),
+                preload_all=eval_cfg.get("preload_all", False),
+            )
+
+            sampler = (
+                DistributedSampler(ds, num_replicas=world_size, rank=rank, shuffle=False)
+                if distributed else None
+            )
+
+            loader = DataLoader(
+                ds,
+                batch_size=eval_cfg.get("batch_size", 1),
+                sampler=sampler,
+                shuffle=False,
+                num_workers=eval_cfg.get("num_workers", 2),
+                collate_fn=collate_anyspecies_padded,
+                worker_init_fn=worker_init_fn,
+            )
+
+            if is_main_process():
+                logger.info(
+                    f"[test-data] dataset={name} split={split} "
+                    f"bvh_dir={ds_cfg['bvh_dir']} size={len(ds)}"
+                )
+
+            test_loaders[name][split] = loader
+
+    return test_loaders
+
+
 # =========================================================
 # eval
 # =========================================================
@@ -241,12 +356,12 @@ def run_evaluation(
     vis_done_species = set()
     max_vis_species = 50
 
-    vis_save_dir = os.path.join(base_dir, f"vis_video2pose2rot_epoch{epoch}")
+    vis_save_dir = os.path.join(base_dir, f"vis_video2pose2rot_epoch{epoch}", tag_prefix)
     if is_main_process() and (epoch + 1) % cfg["train"]["vis_every"] == 0:
         os.makedirs(vis_save_dir, exist_ok=True)
 
     with torch.no_grad():
-        
+
         debug_batch_count = 0
         for batch in tqdm_loader:
             debug_batch_count += 1
@@ -270,7 +385,7 @@ def run_evaluation(
             for k in metric_sums:
                 metric_sums[k] += float(metrics[k]) * bs
 
-            
+
             if is_main_process() and (epoch + 1) % cfg["train"]["vis_every"] == 0:
                 species_list = batch["species"]
                 for si, species_name in enumerate(species_list):
@@ -301,14 +416,14 @@ def run_evaluation(
                         print(f"[VIS] failed on {species_name}: {e}")
 
     sample_count = reduce_sum_scalar(sample_count, device)
-    
+
     for k in metric_sums:
         metric_sums[k] = reduce_sum_scalar(metric_sums[k], device) / max(sample_count, 1)
-            
-    
+
+
     if is_main_process():
         print(
-            f"[Eval] "
+            f"[{tag_prefix}] "
             f"pose_l1={metric_sums['pose_l1']:.6f}, "
             f"pose_l2={metric_sums['pose_l2']:.6f}, "
             f"pose_mpjpe={metric_sums['pose_mpjpe']:.6f}, "
@@ -340,17 +455,17 @@ def train_video2pose2rot_v2pv3(cfg):
     train_cfg = cfg["train"]
     eval_cfg = cfg["eval"]
     output_cfg = cfg["output"]
-    
+
     set_seed(runtime_cfg.get("seed", 42))
 
     base_dir = os.path.join(output_cfg["checkpoint_root"], exp_cfg["exp"])
     os.makedirs(base_dir, exist_ok=True)
-    
+
     # Copy config to checkpoint dir for record
     if is_main_process():
         config_save_path = os.path.join(base_dir, "config.yaml")
         dump_yaml_config(cfg, config_save_path)
-    
+
     logdir = os.path.join(base_dir, "logs_video2pose2rot_v2pv3")
 
     if is_main_process():
@@ -361,20 +476,11 @@ def train_video2pose2rot_v2pv3(cfg):
         device = torch.device(f"cuda:{local_rank}")
     else:
         device = torch.device("cpu")
-        
+
     attention_design = model_cfg["attention_kwargs"]
 
-    dataset_train = AnySpeciesPoseDataset(
-        bvh_dir=data_cfg["bvh_dir"],
-        window=attention_design["seq_len"],
-        mmap=data_cfg.get("mmap", True),
-        cache_scale=data_cfg.get("cache_scale", True),
-        limit_species_debug=data_cfg.get("limit_species_debug", []),
-        split_json=data_cfg["split_json"],
-        split_mode="train",
-        memory_pkl_path=data_cfg["train_memory_pkl_path"],
-        preload_all=data_cfg.get("preload_all", False)
-    )
+    # ---- train data: ConcatDataset across all datasets in the list ----
+    dataset_train = build_train_dataset(data_cfg, attention_design)
 
     sampler_train = (
         DistributedSampler(dataset_train, num_replicas=world_size, rank=rank, shuffle=True)
@@ -391,7 +497,8 @@ def train_video2pose2rot_v2pv3(cfg):
         worker_init_fn=worker_init_fn,
     )
 
-    _, test_loaders = build_test_dataloaders(
+    # ---- test loaders: {dataset_name: {split: loader}} ----
+    test_loaders = build_test_dataloaders_multi(
         data_cfg=data_cfg,
         eval_cfg=eval_cfg,
         attention_design=attention_design,
@@ -399,7 +506,7 @@ def train_video2pose2rot_v2pv3(cfg):
         rank=rank,
         world_size=world_size,
     )
-    
+
     model: torch.nn.Module = instantiate_from_config(model_cfg)
     model = model.to(device)
 
@@ -410,7 +517,7 @@ def train_video2pose2rot_v2pv3(cfg):
             output_device=local_rank,
             find_unused_parameters=True,
         )
-    
+
     lr = train_cfg["lr"]
     weight_decay = train_cfg.get("weight_decay", 0.0)
 
@@ -418,7 +525,7 @@ def train_video2pose2rot_v2pv3(cfg):
         optimizer = optim.Adam(model.parameters(), lr=lr)
     else:
         optimizer = optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
-        
+
     pose_fn = get_loss_fn(train_cfg["loss"].get("pose_loss_type", "smooth_l1"))
     pose_vel_fn = get_loss_fn(train_cfg["loss"].get("pose_vel_loss_type", "smooth_l1"))
     rot_fn = get_loss_fn(train_cfg["loss"].get("rot_loss_type", "smooth_l1"))
@@ -468,9 +575,18 @@ def train_video2pose2rot_v2pv3(cfg):
     global_step = 0
     epochs = train_cfg["epochs"]
     grad_accum_steps = train_cfg.get("grad_accum_steps", 1)
-    
-    split_groups = eval_cfg.get("split_groups", ["seen", "rare", "unseen"])
-    
+
+    # Pick which (dataset, split, metric) drives best-checkpoint selection.
+    # Falls back to the first dataset's first split if not explicitly set.
+    dataset_cfgs = _normalize_dataset_cfgs(data_cfg)
+    default_best_dataset = dataset_cfgs[0]["name"]
+    default_best_split = (
+        dataset_cfgs[0].get("test_splits") or eval_cfg.get("split_groups", ["seen"])
+    )[0]
+    best_metric_dataset = eval_cfg.get("best_metric_dataset", default_best_dataset)
+    best_metric_split = eval_cfg.get("best_metric_split", default_best_split)
+    best_metric_name = eval_cfg.get("best_metric_name", "rot_l1")
+
     for epoch in range(start_epoch, epochs):
         if distributed and isinstance(train_loader.sampler, DistributedSampler):
             train_loader.sampler.set_epoch(epoch)
@@ -584,23 +700,26 @@ def train_video2pose2rot_v2pv3(cfg):
             writer.add_scalar("epoch/pose_pred_prob", pose_pred_prob, epoch + 1)
 
         if (epoch + 1) % train_cfg["test_every"] == 0 or (epoch + 1) == train_cfg["epochs"]:
-            split_metrics = {}
-            for split in split_groups:
-                loader = test_loaders[split]
-                tag_prefix = f"test_{split}"
-                metrics = run_evaluation(
-                    loader=loader,
-                    model=model,
-                    device=device,
-                    attention_design=attention_design,
-                    cfg=cfg,
-                    pose_pred_prob=pose_pred_prob,
-                    writer=writer,
-                    epoch=epoch + 1,
-                    tag_prefix=tag_prefix,
-                    base_dir=base_dir,
-                )
-                split_metrics[split] = metrics
+            # Evaluate on every (dataset, split) pair.
+            # Result shape: {dataset_name: {split: metrics_dict}}
+            all_metrics = {}
+            for ds_name, split_loader_dict in test_loaders.items():
+                all_metrics[ds_name] = {}
+                for split, loader in split_loader_dict.items():
+                    tag_prefix = f"test_{ds_name}_{split}"
+                    metrics = run_evaluation(
+                        loader=loader,
+                        model=model,
+                        device=device,
+                        attention_design=attention_design,
+                        cfg=cfg,
+                        pose_pred_prob=pose_pred_prob,
+                        writer=writer,
+                        epoch=epoch + 1,
+                        tag_prefix=tag_prefix,
+                        base_dir=base_dir,
+                    )
+                    all_metrics[ds_name][split] = metrics
 
             if is_main_process():
                 save_checkpoint_with_epoch(
@@ -612,19 +731,32 @@ def train_video2pose2rot_v2pv3(cfg):
                 )
                 cleanup_old_checkpoints(base_dir, PROCESS_NAME, train_cfg.get("max_ckpt", 100))
 
-                best_metric_split = eval_cfg.get("best_metric_split", "seen")
-                best_metric_name = eval_cfg.get("best_metric_name", "rot_l1")
-                score = split_metrics[best_metric_split][best_metric_name]
-                if score < best_test_loss:
-                    best_test_loss = score
-                    torch.save({
-                        "model_state": (model.module if distributed else model).state_dict(),
-                        "optimizer_state": optimizer.state_dict(),
-                        "epoch": epoch + 1,
-                        "best_test_loss": best_test_loss,
-                        "split_metrics": split_metrics,
-                    }, best_ckpt_path)
-                    print(f"New best checkpoint saved: {best_ckpt_path} ({best_metric_split}/{best_metric_name}={best_test_loss:.6f})")
+                if (
+                    best_metric_dataset in all_metrics
+                    and best_metric_split in all_metrics[best_metric_dataset]
+                    and best_metric_name in all_metrics[best_metric_dataset][best_metric_split]
+                ):
+                    score = all_metrics[best_metric_dataset][best_metric_split][best_metric_name]
+                    if score < best_test_loss:
+                        best_test_loss = score
+                        torch.save({
+                            "model_state": (model.module if distributed else model).state_dict(),
+                            "optimizer_state": optimizer.state_dict(),
+                            "epoch": epoch + 1,
+                            "best_test_loss": best_test_loss,
+                            "all_metrics": all_metrics,
+                        }, best_ckpt_path)
+                        print(
+                            f"New best checkpoint saved: {best_ckpt_path} "
+                            f"({best_metric_dataset}/{best_metric_split}/{best_metric_name}"
+                            f"={best_test_loss:.6f})"
+                        )
+                else:
+                    logger.warning(
+                        f"best_metric tuple "
+                        f"({best_metric_dataset}/{best_metric_split}/{best_metric_name}) "
+                        f"not found in eval results; skipping best-ckpt update."
+                    )
 
     if writer is not None:
         writer.close()


### PR DESCRIPTION
## Summary
Refactored the training pipeline to support training on multiple datasets simultaneously while evaluating each dataset independently on its own test splits. This enables more flexible dataset composition and per-dataset evaluation metrics.

## Key Changes

- **Multi-dataset support**: Introduced `build_train_dataset()` and `build_test_dataloaders_multi()` functions that handle multiple datasets from a configuration list, concatenating them for training and keeping them separate for evaluation.

- **Configuration normalization**: Added `_normalize_dataset_cfgs()` to support both legacy single-dataset configs (with top-level `bvh_dir`/`split_json`) and new multi-dataset format (`data.datasets: [...]`), ensuring backward compatibility.

- **Flexible best-checkpoint selection**: Changed from single split-based selection to a (dataset, split, metric) tuple via `best_metric_dataset`, `best_metric_split`, and `best_metric_name` config parameters. Falls back to the first dataset's first split if not explicitly set.

- **Per-dataset evaluation**: Modified `run_evaluation()` to accept a `tag_prefix` parameter for clearer logging. Updated the evaluation loop to iterate over all (dataset, split) pairs and store results in a nested dictionary structure.

- **Config restructuring**: Updated `train_video2pose2rot.yaml` to use the new `datasets` list format with per-dataset configuration (bvh_dir, split_json, memory paths, test_splits), while keeping shared settings at the top level.

- **Removed unused imports**: Cleaned up imports of `PROCESS_NAME` from `pose2rot` and `build_test_dataloaders` from `video2pose` as they are no longer needed.

## Implementation Details

- Training uses `ConcatDataset` to combine multiple datasets, maintaining proper distributed sampling across all data.
- Test evaluation creates a nested dictionary structure: `{dataset_name: {split: DataLoader}}` for organized per-dataset metrics.
- Checkpoint saving now includes `all_metrics` (nested structure) instead of flat `split_metrics`.
- Added validation to ensure the best-checkpoint metric tuple exists in evaluation results before updating the best checkpoint.
- Minor whitespace cleanup throughout the file.

https://claude.ai/code/session_014cyQqdxeDbuEQeuYW2miGq