### PR TITLE
Add mesh-free preprocessing pipeline for image-only training

### DIFF
--- a/preprocess/README.md
+++ b/preprocess/README.md
@@ -46,6 +46,19 @@ DATA_ROOT=Truebone_Z-OO ZOO_ROOT=zoo BLENDER=/opt/blender/blender PYTHON=python3
 | 10 | `preprocess_data` | `preprocess_data.py` | python + GPU | `zoo/npz_mesh_normed/` + `zoo/image/` | `zoo/npz_train/{motion}/y{deg}.npz` (`latent`, `image_embed`) |
 | 11 | `image_only` | `extract_image_only.py` | python | `zoo/npz_train/` | `zoo/npz_train_image_only/{motion}/y{deg}.npz` (`image_embed` only) |
 
+### Mesh-free alternative
+
+If you do not have `zoo/anim_meshes/` (stage 7 input), skip stages 7-11 and run this stage instead. It produces the same `npz_train_image_only/` artifact directly from `zoo/image/`, which is enough for the `video2pose` / `pose2rot` / `video2pose2rot` training pipelines (only `video2mesh` and `mesh2pose` truly require the mesh latent).
+
+| # | Stage | Script | Tool | Input | Output |
+|---|---|---|---|---|---|
+| 10b | `preprocess_image_only` | `preprocess_image_only.py` | python + GPU | `zoo/image/` | `zoo/npz_train_image_only/{motion}/y{deg}.npz` (`image_embed` only) |
+
+```bash
+STAGES="move_fbx,extract_char,rotate_bvh,extract_pose,render_videos,extract_frames,preprocess_image_only" \
+    bash preprocess/run_pipeline.sh
+```
+
 ## Output tree
 
 ```

--- a/preprocess/preprocess_image_only.py
+++ b/preprocess/preprocess_image_only.py
@@ -1,0 +1,131 @@
+"""
+Encode per-frame images into per-sequence training npz (image embed only).
+
+Use this when you do NOT have animated meshes (i.e. you skipped stages 7-9 of the
+preprocessing pipeline). The output drops the `latent` field and matches what
+`loader_v2.py` expects, so it can be consumed directly without running stage 11.
+
+Reads:
+    {dataset_root}/image/{motion}/{view}/*.png            (one per frame)
+
+Writes:
+    {dataset_root}/npz_train_image_only/{motion}/{view}.npz   (image_embed)
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from models.v1.video2mesh.pipeline_triposg import TripoSGPipeline
+from preprocess.briarmbg import BriaRMBG
+from preprocess.image_process import prepare_image
+
+
+def process_sample(img_files, pipe, rmbg_net, device, dtype, out_file):
+    img_pil_list = []
+    for image_file in img_files:
+        try:
+            img_pil = prepare_image(image_file, bg_color=np.array([1.0, 1.0, 1.0]), rmbg_net=rmbg_net)
+            img_pil_list.append(img_pil)
+        except Exception as e:
+            print(f"Failed preprocessing {image_file}: {e}")
+
+    with torch.no_grad():
+        batch_size = 512  # reduce if GPU memory is tight
+        all_embeds = []
+        for i in range(0, len(img_pil_list), batch_size):
+            chunk = pipe.feature_extractor_dinov2(
+                img_pil_list[i:i + batch_size], return_tensors="pt"
+            ).pixel_values.to(device, dtype=dtype)
+            embeds_chunk = pipe.image_encoder_dinov2(chunk).last_hidden_state
+            all_embeds.append(embeds_chunk.cpu())
+        image_embeds = torch.cat(all_embeds, dim=0)  # [T, 257, 1024]
+
+    np.savez_compressed(
+        out_file,
+        image_embed=image_embeds.cpu().numpy(),
+    )
+
+
+def find_view_dirs(image_root):
+    """Return sorted list of (motion, view) pairs under image_root/{motion}/{view}/*.png."""
+    pairs = []
+    if not os.path.isdir(image_root):
+        return pairs
+    for motion in sorted(os.listdir(image_root)):
+        motion_dir = os.path.join(image_root, motion)
+        if not os.path.isdir(motion_dir):
+            continue
+        for view in sorted(os.listdir(motion_dir)):
+            view_dir = os.path.join(motion_dir, view)
+            if os.path.isdir(view_dir):
+                pairs.append((motion, view))
+    return pairs
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shard", type=int, default=0,
+                        help="current shard id (default 0)")
+    parser.add_argument("--num_shards", type=int, default=1,
+                        help="total number of shards (default 1, single GPU)")
+    parser.add_argument("--dataset_root", type=str, default="zoo",
+                        help="dataset root containing image/")
+    parser.add_argument("--triposg_weights_dir", type=str, default="checkpoints/TripoSG")
+    parser.add_argument("--rmbg_weights_dir", type=str, default="checkpoints/RMBG-1.4")
+    args = parser.parse_args()
+
+    image_folder = os.path.join(args.dataset_root, "image")
+    output_folder = os.path.join(args.dataset_root, "npz_train_image_only")
+
+    print(f"Root Dir:   {args.dataset_root}")
+    print(f" -> Image:  {image_folder}")
+    print(f" -> Output: {output_folder}")
+
+    if not os.path.exists(image_folder):
+        raise FileNotFoundError(f"{image_folder} does not exist; run stage 6 (video_to_images) first.")
+
+    os.makedirs(output_folder, exist_ok=True)
+    device = "cuda"
+    dtype = torch.float16
+
+    rmbg_net = BriaRMBG.from_pretrained(args.rmbg_weights_dir).to(device)
+    rmbg_net.eval()
+
+    print("Loading TripoSG pipeline (DINOv2 image encoder only)...")
+    pipe = TripoSGPipeline.from_pretrained(args.triposg_weights_dir).to(device, dtype)
+
+    view_pairs = find_view_dirs(image_folder)
+    view_pairs = [p for i, p in enumerate(view_pairs) if i % args.num_shards == args.shard]
+    print(f"[INFO] shard {args.shard}/{args.num_shards}, will process {len(view_pairs)} sequences")
+
+    for motion, view in tqdm(view_pairs, desc=f"Shard {args.shard}", unit="seq"):
+        images_dir = os.path.join(image_folder, motion, view)
+        out_file = os.path.join(output_folder, motion, view + ".npz")
+        os.makedirs(os.path.dirname(out_file), exist_ok=True)
+
+        if os.path.exists(out_file):
+            tqdm.write(f"[SKIP] {out_file} already exists, skipping.")
+            continue
+
+        img_files = sorted([
+            os.path.join(images_dir, x)
+            for x in os.listdir(images_dir)
+            if x.lower().endswith((".jpg", ".png"))
+        ])
+
+        if not img_files:
+            tqdm.write(f"[WARN] {images_dir} contains no images, skipping.")
+            continue
+
+        try:
+            process_sample(img_files, pipe, rmbg_net,
+                           device=device, dtype=dtype, out_file=out_file)
+            tqdm.write(f"[DONE] {images_dir} -> {out_file}, {len(img_files)} frames")
+        except Exception as e:
+            tqdm.write(f"[ERROR] {images_dir} processing failed: {e}")

--- a/preprocess/run_pipeline.sh
+++ b/preprocess/run_pipeline.sh
@@ -15,10 +15,17 @@
 #  10. preprocess_data : VAE + DINOv2 encode -> npz_train (GPU)
 #  11. image_only      : strip latent -> npz_train_image_only
 #
+# Mesh-free alternative (skips stages 7-11 when you do not have anim_meshes):
+#  10b. preprocess_image_only : DINOv2 encode straight from image/ -> npz_train_image_only (GPU)
+#
 # Usage:
 #   bash preprocess/run_pipeline.sh                              # run everything
 #   STAGES="rotate_meshes,normalize,preprocess_data" bash preprocess/run_pipeline.sh
 #   DATA_ROOT=Truebone_Z-OO ZOO_ROOT=zoo BLENDER=/path/to/blender bash preprocess/run_pipeline.sh
+#
+#   # Mesh-free path (no anim_meshes available):
+#   STAGES="move_fbx,extract_char,rotate_bvh,extract_pose,render_videos,extract_frames,preprocess_image_only" \
+#       bash preprocess/run_pipeline.sh
 
 set -euo pipefail
 
@@ -115,6 +122,11 @@ if should_run image_only; then
     "$PYTHON" preprocess/extract_image_only.py \
         --input_root "$ZOO_ROOT/npz_train" \
         --output_root "$ZOO_ROOT/npz_train_image_only"
+fi
+
+if should_run preprocess_image_only; then
+    header "10b" "preprocess_image_only (DINOv2 only, GPU)"
+    "$PYTHON" preprocess/preprocess_image_only.py --dataset_root "$ZOO_ROOT"
 fi
 
 echo


### PR DESCRIPTION
## Summary
This PR adds a new preprocessing stage (`preprocess_image_only.py`) that enables training without animated meshes. It allows users to skip stages 7-11 of the preprocessing pipeline and directly generate image embeddings from rendered frames, which is sufficient for pose-based training pipelines.

## Key Changes
- **New script `preprocess_image_only.py`**: Directly encodes per-frame images into training NPZ files containing only image embeddings (DINOv2 features), without requiring mesh data or VAE latents
  - Processes images from `zoo/image/{motion}/{view}/` directory
  - Outputs to `zoo/npz_train_image_only/{motion}/{view}.npz` with only `image_embed` field
  - Supports distributed processing via `--shard` and `--num_shards` arguments
  - Includes background removal (BriaRMBG) and image preprocessing
  - Batches DINOv2 feature extraction for efficiency (512 images per batch)

- **Updated `preprocess/README.md`**: Added documentation for the mesh-free alternative pipeline
  - Explains when to use this path (when `zoo/anim_meshes/` is unavailable)
  - Notes that this output is sufficient for `video2pose`, `pose2rot`, and `video2pose2rot` pipelines
  - Provides example command for running the mesh-free pipeline

- **Updated `preprocess/run_pipeline.sh`**: Integrated the new stage into the pipeline orchestration
  - Added stage 10b (`preprocess_image_only`) as an alternative to stages 7-11
  - Included usage examples for the mesh-free workflow

## Implementation Details
- The script reuses existing utilities (`BriaRMBG`, `prepare_image`, `TripoSGPipeline`) for consistency with the full pipeline
- Output format matches what `loader_v2.py` expects, enabling direct consumption without stage 11
- Includes error handling for individual frame failures and empty directories
- Skips already-processed sequences to support resumable processing

https://claude.ai/code/session_01TAUw3UJSe8L6c6kJVJLAbg