### PR TITLE
Add fast batched BVH renderer

### DIFF
--- a/preprocess/README.md
+++ b/preprocess/README.md
@@ -59,6 +59,42 @@ STAGES="move_fbx,extract_char,rotate_bvh,extract_pose,render_videos,extract_fram
     bash preprocess/run_pipeline.sh
 ```
 
+### Fast BVH video renderer
+
+`render_bvh_videos_fast.py` is a drop-in faster renderer for stage 5. It keeps the same dataset layout as the original renderer:
+
+```text
+zoo/video/{motion}/y{deg}.mp4
+```
+
+Example:
+
+```bash
+BLENDER=/opt/blender/blender python preprocess/render_bvh_videos_fast.py \
+    --zoo-root zoo \
+    --workers 4 \
+    --views y0,y30,y60,y90,y120,y150,y180,y210,y240,y270,y300,y330
+```
+
+The speedup comes from four changes:
+
+- EEVEE is used by default instead of the original Cycles render settings.
+- Multiple BVH views are rendered in batches inside long-lived Blender processes.
+- The character mesh and materials are imported once per Blender worker, then only vertex positions are updated per frame.
+- Frames are rendered directly as the requested image format before ffmpeg encodes the final mp4.
+
+To compare against the original renderer on a small Truebones subset:
+
+```bash
+BLENDER=/opt/blender/blender python preprocess/benchmark_render_bvh_videos.py \
+    --zoo-root zoo \
+    --benchmark-root compare_runs/render_benchmark_10 \
+    --motions 10 \
+    --view y0 \
+    --max-frames 100 \
+    --fast-workers 4
+```
+
 ## Output tree
 
 ```

--- a/preprocess/benchmark_render_bvh_videos.py
+++ b/preprocess/benchmark_render_bvh_videos.py
@@ -1,0 +1,172 @@
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from glob import glob
+from pathlib import Path
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from utils.mesh import BVH, blender_visualize_character_motion
+
+
+def _choose_bvhs(bvh_root, motions, view, motion_filter=None):
+    selected = []
+    for motion_dir in sorted(glob(os.path.join(bvh_root, "*"))):
+        if not os.path.isdir(motion_dir):
+            continue
+        motion_name = os.path.basename(motion_dir)
+        if motion_filter and motion_filter not in motion_name:
+            continue
+        path = os.path.join(motion_dir, f"{view}.bvh")
+        if os.path.exists(path):
+            selected.append(path)
+        if len(selected) >= motions:
+            break
+    return selected
+
+
+def _limited_bvh(src_path, dst_root, max_frames):
+    motion = os.path.basename(os.path.dirname(src_path))
+    view = Path(src_path).stem
+    dst = os.path.join(dst_root, motion, f"{view}.bvh")
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    if max_frames:
+        anim, names, frametime = BVH.load(src_path)
+        anim.positions = anim.positions[:max_frames]
+        anim.rotations = anim.rotations[:max_frames]
+        BVH.save(dst, anim, names, frametime)
+    else:
+        shutil.copy2(src_path, dst)
+    return dst
+
+
+def _run_original(args, bvhs):
+    t0 = time.time()
+    outputs = []
+    for path in bvhs:
+        motion = os.path.basename(os.path.dirname(path))
+        character = motion.split("#")[0]
+        out_dir = os.path.join(args.benchmark_root, "old", motion)
+        os.makedirs(out_dir, exist_ok=True)
+        blender_visualize_character_motion(
+            out_dir,
+            path,
+            character_folder=os.path.join(args.character_root, character),
+            auto_scale="bvh",
+            blender_path=args.blender,
+            hdri_path=args.hdri,
+            view_scale=args.view_scale,
+            object_position=args.object_position,
+            camera_trace=False,
+            fps=args.fps,
+        )
+        outputs.append(os.path.join(out_dir, f"{Path(path).stem}.mp4"))
+        for name in os.listdir(out_dir):
+            full = os.path.join(out_dir, name)
+            if os.path.isdir(full):
+                shutil.rmtree(full)
+            elif not name.endswith(".mp4"):
+                os.remove(full)
+    return {"seconds": time.time() - t0, "outputs": outputs}
+
+
+def _run_fast(args, bvh_root):
+    t0 = time.time()
+    cmd = [
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), "render_bvh_videos_fast.py"),
+        "--zoo-root",
+        args.zoo_root,
+        "--bvh-root",
+        bvh_root,
+        "--character-root",
+        args.character_root,
+        "--output-root",
+        os.path.join(args.benchmark_root, "fast"),
+        "--work-root",
+        os.path.join(args.benchmark_root, "fast_work"),
+        "--blender",
+        args.blender,
+        "--scene",
+        args.scene,
+        "--hdri",
+        args.hdri,
+        "--workers",
+        str(args.fast_workers),
+        "--views",
+        args.view,
+        "--fps",
+        str(args.fps),
+        "--view-scale",
+        str(args.view_scale),
+        "--object-position",
+        str(args.object_position),
+        "--eevee-samples",
+        str(args.eevee_samples),
+        "--image-format",
+        args.image_format,
+    ]
+    subprocess.run(cmd, check=True)
+    return {"seconds": time.time() - t0, "command": cmd}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare original MocapAnything renderer with fast batched renderer.")
+    parser.add_argument("--zoo-root", default="zoo")
+    parser.add_argument("--bvh-root")
+    parser.add_argument("--character-root")
+    parser.add_argument("--benchmark-root", required=True)
+    parser.add_argument("--motions", type=int, default=10)
+    parser.add_argument("--motion-filter")
+    parser.add_argument("--view", default="y0")
+    parser.add_argument("--max-frames", type=int, default=100)
+    parser.add_argument("--blender", default=os.environ.get("BLENDER", "blender"))
+    parser.add_argument("--scene", default=os.path.join("preprocess", "blank.blend"))
+    parser.add_argument("--hdri", default="transparent")
+    parser.add_argument("--fast-workers", type=int, default=4)
+    parser.add_argument("--fps", type=int, default=30)
+    parser.add_argument("--view-scale", type=float, default=1.3)
+    parser.add_argument("--object-position", type=float, default=1.0)
+    parser.add_argument("--eevee-samples", type=int, default=64)
+    parser.add_argument("--image-format", choices=["PNG", "JPEG"], default="PNG")
+    args = parser.parse_args()
+
+    args.bvh_root = args.bvh_root or os.path.join(args.zoo_root, "bvh")
+    args.character_root = args.character_root or os.path.join(args.zoo_root, "characters_fix_facezplus")
+    os.makedirs(args.benchmark_root, exist_ok=True)
+
+    selected = _choose_bvhs(args.bvh_root, args.motions, args.view, args.motion_filter)
+    if len(selected) < args.motions:
+        raise SystemExit(f"Only found {len(selected)} BVHs for view {args.view}; requested {args.motions}.")
+
+    limited_root = os.path.join(args.benchmark_root, "limited_bvh")
+    limited = [_limited_bvh(path, limited_root, args.max_frames) for path in selected]
+    manifest = {
+        "motions": [os.path.basename(os.path.dirname(path)) for path in limited],
+        "motion_filter": args.motion_filter,
+        "view": args.view,
+        "max_frames": args.max_frames,
+    }
+    with open(os.path.join(args.benchmark_root, "manifest.json"), "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+
+    old = _run_original(args, limited)
+    fast = _run_fast(args, limited_root)
+    summary = {
+        **manifest,
+        "original_seconds": old["seconds"],
+        "fast_seconds": fast["seconds"],
+        "speedup": old["seconds"] / fast["seconds"] if fast["seconds"] > 0 else None,
+        "old_outputs": old["outputs"],
+        "fast_output_root": os.path.join(args.benchmark_root, "fast"),
+    }
+    with open(os.path.join(args.benchmark_root, "summary.json"), "w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess/blender_render_bvh_batch.py
+++ b/preprocess/blender_render_bvh_batch.py
@@ -1,0 +1,222 @@
+import argparse
+import csv
+import math
+import os
+import sys
+
+import bpy
+import numpy as np
+from mathutils import Vector
+
+
+def _argv_after_separator():
+    argv = sys.argv
+    return [] if "--" not in argv else argv[argv.index("--") + 1 :]
+
+
+def _import_obj(filepath):
+    before = set(bpy.data.objects.keys())
+    if hasattr(bpy.ops.wm, "obj_import"):
+        bpy.ops.wm.obj_import(filepath=filepath)
+    else:
+        bpy.ops.import_scene.obj(filepath=filepath)
+    new_objects = [obj for obj in bpy.data.objects if obj.name not in before]
+    if not new_objects:
+        raise RuntimeError(f"No object imported from {filepath}")
+    return new_objects[0]
+
+
+def _set_render_engine(engine, samples, image_format, jpeg_quality):
+    scene = bpy.context.scene
+    try:
+        scene.render.engine = engine
+    except Exception:
+        if engine == "BLENDER_EEVEE_NEXT":
+            scene.render.engine = "BLENDER_EEVEE"
+        else:
+            raise
+
+    scene.render.use_persistent_data = True
+    scene.render.image_settings.file_format = image_format
+    scene.render.image_settings.quality = jpeg_quality
+    if hasattr(scene, "eevee"):
+        scene.eevee.taa_render_samples = samples
+        if hasattr(scene.eevee, "use_gtao"):
+            scene.eevee.use_gtao = True
+    if hasattr(scene, "eevee_next"):
+        scene.eevee_next.taa_render_samples = samples
+        if hasattr(scene.eevee_next, "use_gtao"):
+            scene.eevee_next.use_gtao = True
+
+
+def _set_hdri_background(hdri_path):
+    if not hdri_path or hdri_path == "transparent" or not os.path.exists(hdri_path):
+        bpy.context.scene.render.film_transparent = True
+        return
+
+    world = bpy.context.scene.world
+    world.use_nodes = True
+    nodes = world.node_tree.nodes
+    links = world.node_tree.links
+    for node in list(nodes):
+        nodes.remove(node)
+    background = nodes.new(type="ShaderNodeBackground")
+    env_tex = nodes.new(type="ShaderNodeTexEnvironment")
+    output = nodes.new(type="ShaderNodeOutputWorld")
+    env_tex.image = bpy.data.images.load(hdri_path, check_existing=True)
+    links.new(env_tex.outputs["Color"], background.inputs["Color"])
+    links.new(background.outputs["Background"], output.inputs["Surface"])
+    bpy.context.scene.render.film_transparent = False
+
+
+def _smooth_if_no_normal_map(obj):
+    has_normal_map = False
+    for mat in obj.data.materials:
+        if not mat or not mat.use_nodes:
+            continue
+        for node in mat.node_tree.nodes:
+            if node.type == "NORMAL_MAP":
+                has_normal_map = True
+                break
+        if has_normal_map:
+            break
+    if not has_normal_map:
+        for poly in obj.data.polygons:
+            poly.use_smooth = True
+
+
+def _load_vertices_from_obj(path, expected_count):
+    vertices = []
+    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+        for line in handle:
+            if line.startswith("v "):
+                _, x, y, z, *_ = line.split()
+                vertices.extend((float(x), float(y), float(z)))
+    count = len(vertices) // 3
+    if count != expected_count:
+        raise RuntimeError(f"Vertex count mismatch for {path}: {count} != {expected_count}")
+    return vertices
+
+
+def _update_mesh_vertices_from_obj(target_obj, obj_path):
+    mesh = target_obj.data
+    coords = _load_vertices_from_obj(obj_path, len(mesh.vertices))
+    mesh.vertices.foreach_set("co", coords)
+    _smooth_if_no_normal_map(target_obj)
+    mesh.update()
+
+
+def _prepare_base_object(character_folder):
+    base_obj_path = os.path.join(character_folder, "base_mesh.obj")
+    if not os.path.exists(base_obj_path):
+        raise FileNotFoundError(base_obj_path)
+
+    base_obj = _import_obj(base_obj_path)
+    base_obj.rotation_euler = (math.radians(90), 0, 0)
+    if not base_obj.data.materials:
+        return base_obj
+
+    for mat in base_obj.data.materials:
+        if mat is None:
+            continue
+        mat.use_nodes = True
+        nodes = mat.node_tree.nodes
+        links = mat.node_tree.links
+        principled = next((node for node in nodes if node.type == "BSDF_PRINCIPLED"), None)
+        if principled is None:
+            continue
+
+        tex_node = next(
+            (node for node in nodes if node.type == "TEX_IMAGE" and node.image is not None),
+            None,
+        )
+        if tex_node is not None and tex_node.image is not None:
+            tex_name = os.path.basename(bpy.path.abspath(tex_node.image.filepath))
+            tex_path = os.path.join(character_folder, tex_name)
+            if os.path.exists(tex_path):
+                tex_node.image = bpy.data.images.load(tex_path, check_existing=True)
+                base_color = principled.inputs.get("Base Color")
+                if base_color is not None:
+                    for link in list(base_color.links):
+                        links.remove(link)
+                    links.new(tex_node.outputs["Color"], base_color)
+
+        roughness = principled.inputs.get("Roughness")
+        if roughness is not None:
+            roughness.default_value = 0.7
+        normal = principled.inputs.get("Normal")
+        if normal is not None:
+            for link in list(normal.links):
+                links.remove(link)
+        for node in list(nodes):
+            if node.type in {"NORMAL_MAP", "BUMP"}:
+                nodes.remove(node)
+
+    return base_obj
+
+
+def _read_jobs(path):
+    with open(path, "r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        return list(reader)
+
+
+def _frame_extension(image_format):
+    return ".jpg" if image_format.upper() in {"JPEG", "JPG"} else ".png"
+
+
+def _render_job(base_obj, job, image_format):
+    mesh_folder = job["mesh_folder"]
+    output_dir = job["output_dir"]
+    camera_traj = np.load(job["camera_traj"])
+    os.makedirs(output_dir, exist_ok=True)
+    mesh_files = sorted(
+        file_name
+        for file_name in os.listdir(mesh_folder)
+        if file_name.lower().endswith(".obj")
+    )
+    if len(mesh_files) != len(camera_traj):
+        raise RuntimeError(
+            f"Frame count mismatch for {mesh_folder}: {len(mesh_files)} meshes, "
+            f"{len(camera_traj)} camera positions"
+        )
+
+    camera = bpy.data.objects.get("Camera")
+    if camera is None:
+        bpy.ops.object.camera_add()
+        camera = bpy.context.object
+    bpy.context.scene.camera = camera
+    ext = _frame_extension(image_format)
+
+    for frame_idx, file_name in enumerate(mesh_files):
+        _update_mesh_vertices_from_obj(base_obj, os.path.join(mesh_folder, file_name))
+        camera.location = Vector(camera_traj[frame_idx])
+        bpy.context.scene.render.filepath = os.path.join(output_dir, f"{frame_idx:05d}{ext}")
+        bpy.ops.render.render(write_still=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render many BVH mesh sequences in one Blender process.")
+    parser.add_argument("--jobs-file", required=True)
+    parser.add_argument("--scene", required=True)
+    parser.add_argument("--character-folder", required=True)
+    parser.add_argument("--hdri", default="transparent")
+    parser.add_argument("--engine", default=os.environ.get("BLENDER_RENDER_ENGINE", "BLENDER_EEVEE_NEXT"))
+    parser.add_argument("--samples", type=int, default=int(os.environ.get("BLENDER_EEVEE_SAMPLES", "64")))
+    parser.add_argument("--image-format", default=os.environ.get("BLENDER_IMAGE_FORMAT", "PNG"))
+    parser.add_argument("--jpeg-quality", type=int, default=int(os.environ.get("BLENDER_JPEG_QUALITY", "95")))
+    args = parser.parse_args(_argv_after_separator())
+
+    bpy.ops.wm.open_mainfile(filepath=args.scene)
+    _set_render_engine(args.engine, args.samples, args.image_format, args.jpeg_quality)
+    _set_hdri_background(args.hdri)
+    base_obj = _prepare_base_object(args.character_folder)
+
+    jobs = _read_jobs(args.jobs_file)
+    for index, job in enumerate(jobs, start=1):
+        print(f"[BLENDER_BATCH] {index}/{len(jobs)} {job['output_dir']}", flush=True)
+        _render_job(base_obj, job, args.image_format)
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess/render_bvh_videos_fast.py
+++ b/preprocess/render_bvh_videos_fast.py
@@ -1,0 +1,299 @@
+import argparse
+import csv
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from glob import glob
+from pathlib import Path
+
+import numpy as np
+from tqdm import tqdm
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from utils.mesh import BVH, extract_mesh_from_bvh
+from utils.common import get_diameter, interchange_y_z_axis, sm_loop
+from utils.visualization import convert_images_to_video
+
+
+def _split_even(items, chunks):
+    chunks = max(1, min(chunks, len(items)))
+    return [items[index::chunks] for index in range(chunks) if items[index::chunks]]
+
+
+def _select_bvhs(bvh_root, limit=None, motion_filter=None, exact_motion_filter=None, views=None):
+    paths = sorted(glob(os.path.join(bvh_root, "*", "*.bvh")))
+    if motion_filter:
+        paths = [path for path in paths if motion_filter in os.path.basename(os.path.dirname(path))]
+    if exact_motion_filter:
+        keep = set(exact_motion_filter)
+        paths = [path for path in paths if os.path.basename(os.path.dirname(path)) in keep]
+    if views:
+        keep_views = {view[:-4] if view.endswith(".bvh") else view for view in views}
+        paths = [path for path in paths if Path(path).stem in keep_views]
+    if limit:
+        paths = paths[:limit]
+    return paths
+
+
+def _save_limited_bvh(src_path, dst_path, max_frames):
+    if not max_frames:
+        return src_path
+    anim, names, frametime = BVH.load(src_path)
+    if len(anim.positions) <= max_frames:
+        return src_path
+    anim.positions = anim.positions[:max_frames]
+    anim.rotations = anim.rotations[:max_frames]
+    os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+    BVH.save(dst_path, anim, names, frametime)
+    return dst_path
+
+
+def _auto_scale_from_bvh(motion_path):
+    anim, _, _ = BVH.load(motion_path)
+    bone_length = np.linalg.norm(anim.offsets, axis=1)
+    diameter, _ = get_diameter(anim.parents, bone_length)
+    return 1 / diameter
+
+
+def _prepare_job(args, motion_path):
+    motion_name = os.path.basename(os.path.dirname(motion_path))
+    view = Path(motion_path).stem
+    character = motion_name.split("#")[0]
+    character_folder = os.path.join(args.character_root, character)
+    output_dir = os.path.join(args.output_root, motion_name)
+    video_path = os.path.join(output_dir, f"{view}.mp4")
+    if args.skip_existing and os.path.exists(video_path):
+        return {"status": "skipped", "video": video_path}
+
+    job_root = os.path.join(args.work_root, "jobs", motion_name, view)
+    mesh_dir = os.path.join(job_root, "mesh")
+    image_dir = os.path.join(job_root, "images")
+    camera_path = os.path.join(job_root, "camera_trajectory.npy")
+    limited_bvh = os.path.join(args.work_root, "limited_bvh", motion_name, f"{view}.bvh")
+    os.makedirs(mesh_dir, exist_ok=True)
+    os.makedirs(image_dir, exist_ok=True)
+    os.makedirs(output_dir, exist_ok=True)
+
+    render_motion = _save_limited_bvh(motion_path, limited_bvh, args.max_frames)
+    scale = _auto_scale_from_bvh(render_motion) if args.auto_scale == "bvh" else 1.0
+    skin_weight_path = os.path.join(character_folder, "skinning_weights.npy")
+    if not os.path.exists(skin_weight_path):
+        skin_weight_path = os.path.join(character_folder, "skin_weights.npy")
+
+    root_pos = extract_mesh_from_bvh(
+        render_motion,
+        os.path.join(character_folder, "base_mesh.obj"),
+        mesh_dir,
+        skin_weight_path,
+        unicube=False,
+        vis_skeleton=False,
+        return_root_pos=True,
+        mesh_format="obj",
+        scale=scale,
+        mesh_scale=args.mesh_scale,
+        azim=args.azim,
+    )
+
+    root_pos_sm = sm_loop(root_pos, args.traj_smooth)
+    if args.camera_trace:
+        root_pos_sm[:, 2] = -root_pos_sm[:, 2]
+        camera_traj = root_pos_sm + np.array([0, args.object_position, -3.8 / args.view_scale])
+    else:
+        camera_traj = np.tile(
+            np.array([0, args.object_position, -3.8 / args.view_scale]),
+            (root_pos_sm.shape[0], 1),
+        )
+    np.save(camera_path, interchange_y_z_axis(camera_traj))
+
+    return {
+        "status": "ready",
+        "motion": motion_name,
+        "view": view,
+        "character": character,
+        "character_folder": character_folder,
+        "mesh_folder": mesh_dir,
+        "image_dir": image_dir,
+        "camera_traj": camera_path,
+        "video": video_path,
+    }
+
+
+def _write_jobs(path, jobs):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=["mesh_folder", "output_dir", "camera_traj"],
+            delimiter="\t",
+        )
+        writer.writeheader()
+        for job in jobs:
+            writer.writerow(
+                {
+                    "mesh_folder": job["mesh_folder"],
+                    "output_dir": job["image_dir"],
+                    "camera_traj": job["camera_traj"],
+                }
+            )
+
+
+def _run_blender(args, jobs, worker_id):
+    jobs_file = os.path.join(args.work_root, "job_files", f"worker_{worker_id:03d}.tsv")
+    log_file = os.path.join(args.work_root, "logs", f"blender_worker_{worker_id:03d}.log")
+    _write_jobs(jobs_file, jobs)
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    script = os.path.join(os.path.dirname(__file__), "blender_render_bvh_batch.py")
+    cmd = [
+        args.blender,
+        "-b",
+        "--python",
+        script,
+        "--",
+        "--jobs-file",
+        jobs_file,
+        "--scene",
+        args.scene,
+        "--character-folder",
+        jobs[0]["character_folder"],
+        "--hdri",
+        args.hdri,
+        "--engine",
+        args.engine,
+        "--samples",
+        str(args.eevee_samples),
+        "--image-format",
+        args.image_format,
+        "--jpeg-quality",
+        str(args.jpeg_quality),
+    ]
+    with open(log_file, "w", encoding="utf-8") as log:
+        subprocess.run(cmd, stdout=log, stderr=log, check=True)
+
+
+def _encode_job(args, job):
+    convert_images_to_video(job["image_dir"], job["video"], fps=args.fps, crf=args.crf, preset=args.preset)
+    return job["video"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fast batched BVH video renderer for MocapAnything preprocess.")
+    parser.add_argument("--zoo-root", default="zoo")
+    parser.add_argument("--bvh-root")
+    parser.add_argument("--character-root")
+    parser.add_argument("--output-root")
+    parser.add_argument("--work-root")
+    parser.add_argument("--blender", default=os.environ.get("BLENDER", "blender"))
+    parser.add_argument("--scene", default=os.path.join("preprocess", "blank.blend"))
+    parser.add_argument("--hdri", default="transparent")
+    parser.add_argument("--workers", type=int, default=max(1, min(4, os.cpu_count() or 1)))
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--motion-filter")
+    parser.add_argument("--exact-motion-filter", action="append")
+    parser.add_argument("--views", help="Comma-separated view names, e.g. y0,y30")
+    parser.add_argument("--skip-existing", action="store_true")
+    parser.add_argument("--max-frames", type=int, default=0)
+    parser.add_argument("--fps", type=int, default=30)
+    parser.add_argument("--crf", type=int, default=18)
+    parser.add_argument("--preset", default="slow")
+    parser.add_argument("--engine", default=os.environ.get("BLENDER_RENDER_ENGINE", "BLENDER_EEVEE_NEXT"))
+    parser.add_argument("--eevee-samples", type=int, default=int(os.environ.get("BLENDER_EEVEE_SAMPLES", "64")))
+    parser.add_argument("--image-format", choices=["PNG", "JPEG"], default=os.environ.get("BLENDER_IMAGE_FORMAT", "PNG"))
+    parser.add_argument("--jpeg-quality", type=int, default=int(os.environ.get("BLENDER_JPEG_QUALITY", "95")))
+    parser.add_argument("--view-scale", type=float, default=1.3)
+    parser.add_argument("--object-position", type=float, default=1.0)
+    parser.add_argument("--camera-trace", action="store_true")
+    parser.add_argument("--traj-smooth", type=float, default=0.8)
+    parser.add_argument("--auto-scale", choices=["none", "bvh"], default="bvh")
+    parser.add_argument("--mesh-scale", type=float, default=1.0)
+    parser.add_argument("--azim", type=float, default=0.0)
+    parser.add_argument("--cleanup-work", action="store_true")
+    args = parser.parse_args()
+
+    args.bvh_root = args.bvh_root or os.path.join(args.zoo_root, "bvh")
+    args.character_root = args.character_root or os.path.join(args.zoo_root, "characters_fix_facezplus")
+    args.output_root = args.output_root or os.path.join(args.zoo_root, "video")
+    args.work_root = args.work_root or os.path.join(args.zoo_root, "video_fast_work")
+    if args.auto_scale == "none":
+        args.auto_scale = None
+    if args.views:
+        args.views = [item.strip() for item in args.views.split(",") if item.strip()]
+    if not os.path.exists(args.scene):
+        raise SystemExit(f"Blender scene file not found: {args.scene}")
+
+    t0 = time.time()
+    selected = _select_bvhs(
+        args.bvh_root,
+        limit=args.limit,
+        motion_filter=args.motion_filter,
+        exact_motion_filter=args.exact_motion_filter,
+        views=args.views,
+    )
+    if not selected:
+        raise SystemExit("No BVH files matched the requested filters.")
+
+    prepared = []
+    skipped = 0
+    for path in tqdm(selected, desc="Preparing mesh sequences"):
+        job = _prepare_job(args, path)
+        if job["status"] == "skipped":
+            skipped += 1
+        else:
+            prepared.append(job)
+
+    prepare_seconds = time.time() - t0
+    render_seconds = 0.0
+    if prepared:
+        by_character = defaultdict(list)
+        for job in prepared:
+            by_character[job["character"]].append(job)
+
+        worker_jobs = []
+        worker_id = 0
+        for jobs in by_character.values():
+            for part in _split_even(jobs, args.workers):
+                worker_jobs.append((worker_id, part))
+                worker_id += 1
+
+        t_render = time.time()
+        with ThreadPoolExecutor(max_workers=min(args.workers, len(worker_jobs))) as executor:
+            futures = [
+                executor.submit(_run_blender, args, jobs, worker_id)
+                for worker_id, jobs in worker_jobs
+            ]
+            for future in as_completed(futures):
+                future.result()
+        render_seconds = time.time() - t_render
+
+        t_encode = time.time()
+        for job in tqdm(prepared, desc="Encoding videos"):
+            _encode_job(args, job)
+        encode_seconds = time.time() - t_encode
+    else:
+        encode_seconds = 0.0
+
+    summary = {
+        "selected": len(selected),
+        "rendered": len(prepared),
+        "skipped": skipped,
+        "prepare_seconds": prepare_seconds,
+        "render_seconds": render_seconds,
+        "encode_seconds": encode_seconds,
+        "total_seconds": time.time() - t0,
+        "output_root": args.output_root,
+    }
+    os.makedirs(args.work_root, exist_ok=True)
+    with open(os.path.join(args.work_root, "summary.json"), "w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2)
+    print(json.dumps(summary, indent=2))
+
+    if args.cleanup_work:
+        shutil.rmtree(args.work_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/mesh.py
+++ b/utils/mesh.py
@@ -521,6 +521,10 @@ def blender_visualize_single_mesh_sequence(
     current_dir = os.path.dirname(__file__)
     blender_py_path = os.path.join(current_dir, "blender_mesh_utils.py")
     scene_blend_path = os.path.join(current_dir, scene + ".blend")
+    if not os.path.exists(scene_blend_path):
+        scene_blend_path = os.path.join(
+            os.path.dirname(current_dir), "preprocess", scene + ".blend"
+        )
 
     blender_cmd = [
         blender_path,


### PR DESCRIPTION
- EEVEE is used by default instead of the original Cycles render settings.
- Multiple BVH views are rendered in batches inside long-lived Blender processes.
- The character mesh and materials are imported once per Blender worker, then only vertex positions are updated per frame.
- Frames are rendered directly as the requested image format before ffmpeg encodes the final mp4.