### PR TITLE
Fix fresh-install issues found by end-to-end clone test

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A reference frame from a matching species guides the per-species skeleton and sc
 Clone the repo, grab the weights + demo data from HuggingFace, and run the bundled examples (or your own videos) end-to-end — no dataset preprocessing required.
 
 ```bash
-pip install torch torchvision numpy trimesh pyyaml tqdm huggingface_hub pillow imageio imageio-ffmpeg transformers gradio
+pip install torch torchvision numpy opencv-python pillow matplotlib scipy scikit-image trimesh roma pyyaml tqdm huggingface_hub transformers gradio imageio-ffmpeg
 
 # Weights → ./checkpoints/   ·   Demo data (~160 MB, 1-frame references) → ./demo/data/
 hf download kehong/MoCapAnythingV2-weights --local-dir ./checkpoints
@@ -62,7 +62,7 @@ python inference/video2pose2rot.py --config demo/configs/demo_zoo.yaml
 python demo/app.py            # http://localhost:7860
 ```
 
-> Rendering requires a Blender binary (4.x/5.x) on `PATH` — see [RUN.md](RUN.md) for the `blender_mocapanything.sh` wrapper and env vars. Checkpoints and datasets live on HuggingFace; only code ships in this repo. The background remover (`briaai/RMBG-1.4`) and DINOv2 auto-download on first run.
+> The 3D mesh render needs a portable [Blender](https://www.blender.org/download/) build (4.x/5.x): extract it and `export BLENDER_BIN=/path/to/blender` — without it you still get pose `.npy` + BVH + skeleton videos. Checkpoints and datasets live on HuggingFace; only code ships in this repo. The background remover (`briaai/RMBG-1.4`) and DINOv2 auto-download on first run. If torch complains your NVIDIA driver is too old, install a build matching your driver from [pytorch.org](https://pytorch.org/get-started/locally/) (tested: `torch==2.9.0`).
 
 ## Install & Run
 

--- a/RUN.md
+++ b/RUN.md
@@ -22,13 +22,16 @@ A reference frame (a single pose from a matching species) is used to guide the p
 
 Clone the repo, grab the weights + demo data from HuggingFace, and you can run the bundled examples (or your own videos) end-to-end — no dataset preprocessing required.
 
-**1. Clone + environment**
+**1. Clone + environment** (Python ≥ 3.10 recommended)
 ```bash
 git clone https://github.com/phongdaot/MocapAnything.git
 cd MocapAnything
-pip install torch torchvision numpy trimesh pyyaml tqdm tensorboard huggingface_hub pillow imageio imageio-ffmpeg transformers gradio
+pip install torch torchvision numpy opencv-python pillow matplotlib scipy scikit-image \
+    trimesh roma pyyaml tqdm huggingface_hub transformers gradio imageio-ffmpeg
 # TripoSG is only needed for the V1 video2mesh baseline; the V2 demo does not require it.
+# (Alternatively `pip install -r requirements.txt` reproduces the exact tested environment.)
 ```
+> **PyTorch/CUDA:** pip's default `torch` wheel targets the newest CUDA and may fail on older drivers with `The NVIDIA driver on your system is too old` (which then surfaces as `torch.cat(): expected a non-empty list of Tensors` during feature extraction). If you hit that, install a build matching your driver from [pytorch.org](https://pytorch.org/get-started/locally/), e.g. `pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126`, or use the tested pin `torch==2.9.0`.
 
 **2. Download weights + demo data from HuggingFace**
 ```bash
@@ -42,11 +45,19 @@ hf download kehong/MoCapAnythingV2-data-sample --repo-type dataset --local-dir .
 > The demo ships **1-frame** reference features (only frame 0 of each reference is needed at inference — verified bit-identical to the full features). A full mini-dataset unlocking all **73 species** as retarget targets will be released later; once available, download it into `./datasets/zoo1030/` and it overrides the demo subset by same-name files.
 
 **3. Configure rendering (for 3D mesh output)**
+
+Download a **portable Blender build (4.x / 5.x)** from [blender.org/download](https://www.blender.org/download/) and extract it anywhere — no installation needed. Then point `BLENDER_BIN` to the binary:
 ```bash
-export BLENDER_BIN=/path/to/blender          # Blender 4.x/5.x binary (required for 3D render)
-export MOCAP_ENV_LIB=$CONDA_PREFIX/lib        # optional: adds conda libs to LD_LIBRARY_PATH
-# ffmpeg must be on PATH — it ships with the conda env, or `conda install ffmpeg`
+export BLENDER_BIN=/path/to/blender-4.x-linux-x64/blender   # required for the 3D mesh render
+# ffmpeg is NOT required system-wide — the pipeline uses the binary bundled with the `imageio-ffmpeg` wheel.
 ```
+On **headless servers** Blender may fail with `error while loading shared libraries: libxkbcommon.so.0` (or similar X11/GL libs). Fix either way:
+```bash
+sudo apt install -y libxkbcommon0 libgl1 libxi6 libxrender1      # Debian/Ubuntu
+# …or, without root: point MOCAP_ENV_LIB at any conda env's lib that ships these
+export MOCAP_ENV_LIB=$CONDA_PREFIX/lib
+```
+Without Blender everything still runs — you get the pose `.npy` + BVH + skeleton videos, just no textured mesh render.
 
 **4. Run the bundled examples (command line)**
 ```bash
@@ -55,13 +66,17 @@ export PYTHONPATH=$PWD:$PWD/TripoSG
 python inference/video2pose2rot.py --config demo/configs/demo_zoo.yaml
 # 5 object videos
 python inference/video2pose2rot.py --config demo/configs/demo_obj.yaml
-# 5 in-the-wild animal videos (no GT — conditions on a same-species reference skeleton)
+# in-the-wild animal videos (no GT — conditions on a same-species reference skeleton).
+# 25 videos ship; the 10 whose species have a reference in the mini demo dataset are
+# processed, the rest are skipped with a warning (they unlock with the full dataset).
 python inference/video2pose2rot.py --config demo/configs/demo_wild.yaml
 ```
 Each sequence produces, under `demo_outputs/`:
 - `*_pose_pred.npy`, `*_rot6d_pred.npy` — predicted joint positions and rotations
 - a BVH file — animation-ready joint rotations
 - `*_final.mp4` — a side-by-side of **input video | pose skeleton (2 views) | 3D mesh render (2 views)**
+
+> **What success looks like:** the `expected_results/` folder in the [data-sample repo](https://huggingface.co/datasets/kehong/MoCapAnythingV2-data-sample/tree/main/expected_results) holds reference `*_final.mp4` outputs for five of the wild examples (Chicken, Dog, Eagle, Jaguar, Leopard) — your runs should look the same.
 
 **5. Interactive web demo (Gradio)**
 ```bash
@@ -101,7 +116,7 @@ MocapAnything/
 
 2. Create a Python environment and install PyTorch (CUDA build matching your hardware) plus the usual ML stack:
    ```bash
-   pip install torch torchvision numpy trimesh pyyaml tqdm tensorboard huggingface_hub pillow
+   pip install -r requirements.txt   # or the minimal list from Quick Start, plus tensorboard for training
    ```
 
 3. Install the TripoSG dependency used by the `video2mesh` pipeline (see the TripoSG repository for details) and place it on your `PYTHONPATH` so `from TripoSG.triposg... ` imports resolve.

--- a/inference/video2pose2rot.py
+++ b/inference/video2pose2rot.py
@@ -620,8 +620,9 @@ def inference(cfg, device, attention_design, model, pipe, rmbg_net, seq_name, im
     if cfg["output"].get("blender_path", None) is not None and os.path.exists(cfg["output"]["blender_path"]):
         if stage_cb is not None:
             stage_cb("render")
-        
-        for azim in [(0, "camera"), (-60, "side")]:  # 只渲 camera+side(省 33% 渲染)
+
+        try:
+          for azim in [(0, "camera"), (-60, "side")]:  # 只渲 camera+side(省 33% 渲染)
 
             output_dir = os.path.join(save_dir, azim[1])
             video_exists = any(
@@ -667,6 +668,9 @@ def inference(cfg, device, attention_design, model, pipe, rmbg_net, seq_name, im
             #         bg_color=(255, 255, 255),
             #         azim=zim,
             #     )
+        except Exception as _re:
+            logger.warning(f"[render skip] {species_name}: Blender render failed ({_re}); "
+                           f"pose/BVH outputs are already saved — check BLENDER_BIN if you want the mesh render.")
 
         # 沙盒:mesh 渲完 → 一步到位拼最终布局(web demo):
         #   输入 | 骨架cam | mesh_cam | 骨架side | mesh_side(统一高 400 横拼)

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,6 +112,7 @@ pycparser==2.22
 pycryptodome==3.23.0
 pydantic==2.12.5
 pydantic_core==2.41.5
+pygltflib==1.16.5
 pyemd==1.1.0
 Pygments==2.19.1
 pymeshlab==2025.7

--- a/utils/common.py
+++ b/utils/common.py
@@ -242,6 +242,7 @@ def extract_and_compare_image_features_with_rmbg(
 
     # 1. Preprocess images using prepare_image + RMBG
     img_pil_list = []
+    first_err = None
     for image_file in img_files:
         try:
             pil = prepare_image(
@@ -249,7 +250,16 @@ def extract_and_compare_image_features_with_rmbg(
             )
             img_pil_list.append(pil)
         except Exception as e:
+            first_err = first_err or e
             print(f"Failed to process {image_file}: {e}")
+    if not img_pil_list:
+        # 全部帧失败 → 直接给出真实原因(常见:torch CUDA wheel 与显卡驱动不匹配),
+        # 否则会在下游报隐晦的 torch.cat empty-list 错误。
+        raise RuntimeError(
+            f"All {len(img_files)} frames failed preprocessing in {image_folder}. "
+            f"First error: {first_err}. If it mentions the NVIDIA driver being too old, "
+            f"install a torch build matching your driver (see https://pytorch.org/get-started/locally/)."
+        )
 
     # 2. Extract features using pipeline's DINO model
     all_embeds = []

--- a/utils/visualization.py
+++ b/utils/visualization.py
@@ -12,6 +12,15 @@ from . import bvh as BVH
 from .common import parent_to_kinematic_tree
 import shutil
 
+
+def _ffmpeg_exe():
+    """优先用 imageio-ffmpeg 自带的 ffmpeg(pip 即有,无需系统安装);回退 PATH。"""
+    try:
+        import imageio_ffmpeg
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except Exception:
+        return shutil.which("ffmpeg")
+
 def plot_bvh_compare(
     pred_bvh_path: str,
     gt_bvh_path: str,
@@ -602,7 +611,7 @@ def plot_pose_compare_from_npy(
     # Concatenate videos
     # =========================================================
     if save_type == "mp4":
-        ffmpeg_path = shutil.which("ffmpeg")
+        ffmpeg_path = _ffmpeg_exe()
         if ffmpeg_path is None:
             print("[WARN] ffmpeg not found. Separate videos were saved, but concatenation was skipped.")
         else:
@@ -726,7 +735,7 @@ def convert_images_to_video(image_dir, video_path, fps=20, crf=18, preset="slow"
         pattern = os.path.join(image_dir, "*.jpeg")
 
     cmd = [
-        "ffmpeg",
+        _ffmpeg_exe() or "ffmpeg",
         "-y",
         "-framerate", str(fps),
         "-pattern_type", "glob",


### PR DESCRIPTION
Validated by a full fresh-user E2E (temp dir, clean venv, new HF cache, public repos only): clone → pip install → HF download → `demo_wild` inference → Blender render, **all pass**; outputs match `expected_results/`.

Issues found & fixed:
1. **Docs — pip deps incomplete**: opencv/matplotlib/scipy/scikit-image/roma missing → ImportError on first run
2. **Docs — torch/CUDA**: pip default torch wheel (cu130) fails on older drivers; added guidance + tested pin `torch==2.9.0`
3. **Docs — Blender setup**: portable-build install guide; headless servers need `libxkbcommon`/`libGL` (apt or `MOCAP_ENV_LIB`)
4. **Code — system ffmpeg required**: `utils/visualization.py` called bare `ffmpeg`; now uses the imageio-ffmpeg bundled binary
5. **Code — cryptic error**: all-frames-failed now reports the real cause (was `torch.cat(): expected a non-empty list`)
6. **Code — robustness**: Blender render failure no longer aborts a sample (pose/BVH still saved)
7. requirements.txt: add `pygltflib`; docs: `expected_results/` reference videos on HF

🤖 Generated with [Claude Code](https://claude.com/claude-code)