### PR TITLE
Fix preprocessing bugs and add a custom-rig workflow (own skeleton ->…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ python demo/app.py            # http://localhost:7860
 
 > The 3D mesh render needs a portable [Blender](https://www.blender.org/download/) build (4.x/5.x): extract it and `export BLENDER_BIN=/path/to/blender` — without it you still get pose `.npy` + BVH + skeleton videos. Checkpoints and datasets live on HuggingFace; only code ships in this repo. The background remover (`briaai/RMBG-1.4`) and DINOv2 auto-download on first run. If torch complains your NVIDIA driver is too old, install a build matching your driver from [pytorch.org](https://pytorch.org/get-started/locally/) (tested: `torch==2.9.0`).
 
+## Use your own rigged character
+
+The preprocessing pipeline is not tied to the released datasets. Point it at your own rigged
+FBX and it produces the same artifacts inference consumes — skeleton topology, joint-name
+embeddings, reference poses — so you can drive *your* rig with in-the-wild footage.
+
+```bash
+export BLENDER=/path/to/blender PYTHON=/path/to/torch/python
+bash examples/custom_rig/run.sh MyRig
+python -m inference.video2pose2rot --config examples/custom_rig/inference.yaml
+```
+
+Walkthrough, required file layout, and troubleshooting: **[examples/custom_rig/README.md](examples/custom_rig/README.md)**.
+Stage-by-stage reference: **[preprocess/README.md](preprocess/README.md)**.
+
 ## Install & Run
 
 Environment setup, dataset layout, training commands, and inference (including in-the-wild mode) live in **[RUN.md](RUN.md)**.

--- a/RUN.md
+++ b/RUN.md
@@ -100,7 +100,8 @@ MocapAnything/
 ├── models/
 │   ├── v1/               # mesh2pose, video2mesh (TripoSG)
 │   └── v2/               # video2pose, video2pose2, pose2rot, video2pose2rot
-├── preprocess/           # Image preprocessing, background removal, data preparation
+├── preprocess/           # Raw FBX → training/inference data (see preprocess/README.md)
+├── examples/custom_rig/  # Bring your own rigged FBX: walkthrough, runner, inference config
 ├── train/                # Training entrypoints (one per stage)
 ├── inference/            # Inference entrypoints (one per stage)
 └── utils/                # Common utilities: loss, rotation, mesh, BVH, visualization, etc.
@@ -144,7 +145,29 @@ datasets/zoo1030/
 └── cache/                            # Per-species scale cache
 ```
 
-Use `preprocess/preprocess_data.py` to build mesh and image caches from raw sequences. The released end-to-end model trains without FPS memory banks (it conditions on the reference frame directly), so `num_memory: -1` in the config; per-species memory banks are only needed for the standalone `pose2rot` variants.
+Every one of those files is produced by `preprocess/run_pipeline.sh`, starting from raw FBX — see [`preprocess/README.md`](preprocess/README.md) for the stage-by-stage breakdown. The two that inference refuses to start without:
+
+| File | Built by |
+|---|---|
+| `species_info_dict.npy` | `preprocess/build_species_info.py` (stage 7) — skeleton topology, joint-name T5 embeddings, static joints |
+| `cache/__mesh2pose1002_species_scale_cache.pkl` | `preprocess/build_scale_cache.py` (stage 8) — per-species normalization scale |
+
+The released end-to-end model trains without FPS memory banks (it conditions on the reference frame directly), so `num_memory: -1` in the config; per-species memory banks are only needed for the standalone `pose2rot` variants.
+
+### Using your own rigged character
+
+The pipeline is not tied to this dataset. Point it at your own FBX and it produces the same
+artifacts, which is all inference needs:
+
+```bash
+export BLENDER=/path/to/blender PYTHON=/path/to/torch/python
+bash examples/custom_rig/run.sh MyRig
+python -m inference.video2pose2rot --config examples/custom_rig/inference.yaml
+```
+
+See [`examples/custom_rig/README.md`](examples/custom_rig/README.md) for what to prepare,
+what each stage produces, and what to do when the automatic facing-direction or leaf-bone
+guesses come out wrong.
 
 ## Training
 
@@ -190,6 +213,8 @@ Inference scripts read the same YAML configs (inference variants) and operate on
 - **Evaluation mode** (`data.wild_flag: false`) — compares predictions against GT sequences and reports metrics.
 - **Wild mode** (`data.wild_flag: true`) — runs on in-the-wild image sequences using only a reference pose.
 
+In wild mode, also set `data.wild_mode: true` to have the reference skeleton resolved from the clip filename: `MyRig#clip.mp4` picks any `MyRig#` sequence out of `data.base_dir`. Without it, a clip whose species has no ground-truth entry is skipped with a `[SKIP] ... ref bvh_pose` warning.
+
 ```bash
 # Video → Mesh
 python -m inference.video2mesh --config configs/inference/inference_video2mesh.yaml
@@ -202,6 +227,9 @@ python -m inference.video2pose --config configs/inference/inference_video2pose.y
 
 # End-to-end Video → Pose → Rotation (outputs BVH)
 python -m inference.video2pose2rot --config configs/inference/inference_video2pose2rot.yaml
+
+# Your own rig, driven by in-the-wild footage
+python -m inference.video2pose2rot --config examples/custom_rig/inference.yaml
 ```
 
 Outputs are written to `output.save_dir` and include predicted pose `.npz` files, rotation sequences, BVH files, and (if Blender is configured) rendered comparison videos.

--- a/configs/inference/inference_video2pose2rot.yaml
+++ b/configs/inference/inference_video2pose2rot.yaml
@@ -8,13 +8,13 @@ runtime:
   seed: 42
 
 weights:
-  video2pose_ckpt_root: "./checkpoints/video2pose2rot"
+  video2pose_ckpt_root: "./checkpoints"
   triposg_weights_dir: "./checkpoints/TripoSG_temporal"
   rmbg_weights_dir: "./checkpoints/RMBG-1.4"
-  ckpt_name: "video2pos2rot_ckpt_best.pt"
+  ckpt_name: "video2pos2rot_epoch60.pt"
 
 experiment:
-  exp: "video2pos2rot_exp1_mixGT2Pred_detach_stage1stable"
+  exp: ""
 
 model:
   target: models.v2.video2pose2rot.model.Video2Pose2RotModel
@@ -24,7 +24,7 @@ model:
       target: models.v2.video2pose.model.RefGuidedVideo2PoseModel
       params:
         q_dim: 256
-        num_layers: 12
+        num_layers: 8
         num_heads: 8
         ref_layers: 4
         img_dim: 1024
@@ -42,7 +42,7 @@ model:
         rest_layers: 4
         pose_layers: 4
         memory_layers: 4
-        decoder_layers: 10
+        decoder_layers: 8
         num_heads: 8
         joint_embed_dim: 768
         temporal_window: 2
@@ -56,7 +56,7 @@ model:
         decoder_use_cross_layers: 6
   
   attention_kwargs:
-    seq_len: 24
+    seq_len: 32
     selfatt_temporal_layer_flag: []
     selfatt_temporal: true
     crossatt2_temporal: true
@@ -80,6 +80,8 @@ data:
     ref_idx: 0
   
   wild_flag: false # if true, no ground truth provided for inference, only reference frame is used as input, and the output will be saved in output folder without evaluation. If false, GT pose sequence will be provided as input, and the output will be evaluated against GT and saved in output folder.
+
+  wild_mode: false # if true, the reference skeleton is picked from base_dir by the species prefix of the input clip's filename ("MyRig#clip.mp4" -> any MyRig# sequence). Use this to drive a rig with in-the-wild footage that has no ground truth.
 
   max_pts: 1024
 

--- a/examples/custom_rig/README.md
+++ b/examples/custom_rig/README.md
@@ -1,0 +1,163 @@
+# Bringing your own rig
+
+Drive **your own rigged character** with an in-the-wild video. Nothing here is
+specific to the released datasets — point the pipeline at your FBX and it produces
+the same artifacts the shipped `zoo1030` / `obj1k` data is made of, then runs
+inference against them.
+
+The worked example below retargets in-the-wild **eagle** footage onto a **parrot**
+rig, so it also shows the cross-species case: the input species does not have to
+match your rig.
+
+> **No character assets ship with this repo.** The example was built from the
+> Truebones Zoo `Parrot`, whose terms of use forbid redistribution. Bring your own
+> FBX, or obtain Truebones Zoo from its original source.
+
+---
+
+## What you need
+
+| | |
+|---|---|
+| A rigged character | one FBX with the mesh + skeleton (the *base*), plus at least one FBX holding a motion |
+| Blender | 3.6+; set `BLENDER=/path/to/blender` |
+| Python env | the one from [`../../RUN.md`](../../RUN.md) — must have torch, used for the non-Blender stages |
+| An input video | any clip of a real animal/person; a matte (no background) works best |
+
+The base FBX is picked automatically: the one with the **shortest filename** in the
+folder. Name your files so that holds — e.g. `MyRig.fbx` plus `MyRig-Walk.fbx`.
+
+## Layout
+
+```
+Truebone_Z-OO/
+└── MyRig/
+    ├── MyRig.fbx          # base: mesh + skeleton  (shortest name → detected as base)
+    ├── MyRig-Walk.fbx     # one or more motions
+    └── tex/               # optional textures
+videos/
+└── MyRig#clip.mp4         # input footage; the part before '#' must match the rig name
+```
+
+The `MyRig#` prefix on the video is how inference finds your reference skeleton, so
+it has to match the folder name exactly.
+
+## Run it
+
+```bash
+export BLENDER=/path/to/blender
+export PYTHON=/path/to/your/python        # the torch env, NOT Blender's
+
+bash examples/custom_rig/run.sh MyRig
+```
+
+That is the mesh-free path through [`../../preprocess/run_pipeline.sh`](../../preprocess/run_pipeline.sh)
+— stages 1–10 plus 14b, skipping everything that needs `anim_meshes/`. It produces:
+
+```
+zoo/
+├── fixed_fbx/MyRig/              # 2. no-weight leaf bones removed
+├── characters_face_zplus/MyRig/  # 3+4. mesh, skinning, rest.bvh, MyRig_ffs.bvh, front.npy
+├── motions_face_zplus/           # 4.  motions rotated to face +Z
+├── bvh/MyRig#*/y*.bvh            # 5.  12 yaw views
+├── bvh_pose/MyRig#*/y*.npz       # 6.  positions + rot6d + traj
+├── species_info_dict.npy         # 7.  topology + joint-name T5 embeddings + static joints
+├── cache/…scale_cache.pkl        # 8.  per-species normalization scale
+├── video/, image/                # 9+10.
+└── npz_train_image_only/         # 14b. DINOv2 reference embeddings
+```
+
+Then inference:
+
+```bash
+$PYTHON -m inference.video2pose2rot --config examples/custom_rig/inference.yaml
+```
+
+Output lands in `outputs/custom_rig/`: a `*_final.mp4` five-panel clip
+(input | skeleton | mesh, two camera angles), `*_rot6d_pred.bvh`, `*_pose_pred.npy`,
+and per-frame `.obj` meshes.
+
+---
+
+## When the automatic steps get it wrong
+
+Two stages make guesses about your rig, and neither one *fails* when it guesses wrong —
+the pipeline runs to completion and the output is just subtly off.
+
+### Facing direction
+
+Stage 4 infers which way your character faces and rotates it to +Z. On rigs with
+too much symmetry it gives up:
+
+```
+[ERROR] MyRig: Symmetry of size >= 3 found
+```
+
+`run.sh` halts there rather than letting the remaining stages build a whole dataset
+out of unaligned motions. Supply the facing direction yourself — a unit vector in the
+rig's own coordinates pointing out of the character's **front**:
+
+```bash
+mkdir -p examples/custom_rig/align_ref/MyRig
+$PYTHON -c "import numpy as np; np.save('examples/custom_rig/align_ref/MyRig/front.npy', np.array([1.,0.,0.]))"
+ALIGN_REF_DIR=examples/custom_rig/align_ref bash examples/custom_rig/run.sh MyRig
+```
+
+`[1,0,0]` means the character faces +X, `[0,0,1]` means it already faces +Z, and so
+on. The parrot in the worked example needs `[1,0,0]`.
+
+The case nothing can catch for you is a *confidently wrong* inference: it produces a
+`front.npy`, so the run continues, and you only notice because the mesh is rotated in
+the output video while the skeleton looks fine. If you see that, set `front.npy`
+explicitly and rerun — deleting `$ZOO_ROOT/characters_face_zplus/MyRig/` first, since
+stage 4 skips characters it has already aligned.
+
+### Leaf-bone cleanup
+
+Stage 2 deletes leaf bones that carry no skin weights, because that is what the
+released datasets were built with — 3ds Max Biped adds a `*Nub` bone at the end of
+every chain and they must not become joints. `preprocess/fix_fbx.py` also keeps an
+`INVERSE_LIST` of characters whose inferred facing needs flipping; your rig will not
+be on it.
+
+If your rig has meaningful weightless leaves, skip the stage:
+
+```bash
+STAGES="move_fbx,extract_char,align_faces,rotate_bvh,extract_pose,species_info,scale_cache,render_videos,extract_frames,preprocess_image_only" \
+    bash preprocess/run_pipeline.sh
+```
+
+### Joint names
+
+`species_info_dict.npy` embeds each joint's *name* with T5, and the model uses those
+embeddings to reason about what each joint is. Names are cleaned automatically
+(`mixamorig:LeftUpLeg` → `Left Up Leg`), which is exactly how the `obj1k` half of
+the training data was built, so descriptive names work well.
+
+Two things to know:
+
+- Trailing digits are stripped, so `Tail_01 … Tail_07` all collapse to `Tail` and
+  share one embedding. If ordinals matter for your rig, spell them out.
+- The `zoo1030` half of the training data uses curated names (`flyer tail 01`)
+  rather than raw ones. To match that convention, hand-write the mapping and pass
+  it in:
+
+  ```bash
+  $PYTHON preprocess/build_species_info.py --dataset_root zoo \
+      --joint_name_map examples/custom_rig/joint_name_map.json
+  ```
+
+  The file is `{"MyRig": {"<bone name in the FBX>": "<readable name>", …}}`.
+
+---
+
+## Verified scope
+
+The pipeline was validated end-to-end on a Truebones Zoo rig: the rebuilt
+`species_info_dict.npy` matches the released `zoo1030` entry exactly on
+`joints_name`, `joints_distance`, `joint_relation`, `rename_clean` and
+`static_joints`, with joint-name embeddings at cosine 1.000000.
+
+Not yet validated on Mixamo, Maya HumanIK or hand-built Blender rigs. The leaf-bone
+cleanup in particular assumes 3ds Max Biped conventions. If you try one, an issue
+report is welcome.

--- a/examples/custom_rig/inference.yaml
+++ b/examples/custom_rig/inference.yaml
@@ -1,0 +1,104 @@
+### examples/custom_rig/inference.yaml ###
+# Drive your own rig with in-the-wild footage, using the data that
+# examples/custom_rig/run.sh just produced under ./zoo.
+#
+# Differences from configs/inference/inference_video2pose2rot.yaml:
+#   - data.* point at ./zoo (your rig) instead of ./datasets/zoo1030
+#   - character_dir is characters_face_zplus (the aligned rest poses)
+#   - memory_pkl_path is empty: no FPS memory bank is built for a custom rig,
+#     so the model falls back to the reference frame
+#   - wild_flag + wild_mode are both true: no ground truth, reference skeleton
+#     resolved from the clip filename prefix
+#
+# Set BLENDER_BIN before running, or the mesh render is skipped:
+#   export BLENDER_BIN=/path/to/blender
+name: "Custom rig video2pose2rot inference"
+
+runtime:
+  device: "cuda"
+  dtype: "float16"
+  seed: 42
+
+weights:
+  video2pose_ckpt_root: "./checkpoints"
+  rmbg_weights_dir: "briaai/RMBG-1.4" # pulled from HF at runtime; use ./checkpoints/RMBG-1.4 if you mirrored it
+  ckpt_name: "video2pos2rot_epoch60.pt"
+
+experiment:
+  exp: ""
+
+model:
+  target: models.v2.video2pose2rot.model.Video2Pose2RotModel
+  params:
+
+    v2p_cfg:
+      target: models.v2.video2pose.model.RefGuidedVideo2PoseModel
+      params:
+        q_dim: 256
+        num_layers: 8
+        num_heads: 8
+        ref_layers: 4
+        img_dim: 1024
+        num_joints: 150
+        use_graph_ref_outer: false
+        use_graph_ref_inner: true
+        use_graph_temporal_outer: false
+        use_graph_temporal_inner: true
+        use_joint_embed: true
+
+    p2r_cfg:
+      target: models.v2.pose2rot.model.Pose2RotMemoryRestModel
+      params:
+        q_dim: 256
+        rest_layers: 4
+        pose_layers: 4
+        memory_layers: 4
+        decoder_layers: 8
+        num_heads: 8
+        joint_embed_dim: 768
+        temporal_window: 2
+        temporal_dropout: 0.1
+        decoder_cond_mode: add # add | concat
+        pose_rest_film: true
+        memory_rest_film: true
+        decoder_rest_film: true
+        pose_use_graph: true
+        use_grad_checkpoint: false
+        decoder_use_cross_layers: 6
+
+  attention_kwargs:
+    seq_len: 32
+    selfatt_temporal_layer_flag: []
+    selfatt_temporal: true
+    crossatt2_temporal: true
+    selfatt_slidwindow: 5
+    crossatt2_slidwindow: 5
+
+data:
+  base_dir: "./zoo"
+  character_dir: "./zoo/characters_face_zplus"
+  memory_pkl_path: ""
+  scale_dict_path: "./zoo/cache/__mesh2pose1002_species_scale_cache.pkl"
+  bvh_roots:
+    - "./zoo/bvh"
+
+  image_roots:
+    - "./videos"
+
+  retarget:
+    toggle: false
+    ref_seq: ""
+    ref_idx: 0
+
+  wild_flag: true # no ground truth: only the reference frame is used as input, and nothing is evaluated
+
+  wild_mode: true # reference skeleton is picked from base_dir by the clip's filename prefix ("MyRig#clip.mp4" -> any MyRig# sequence)
+
+  max_pts: 1024
+
+output:
+  blender_path: "./blender_mocapanything.sh" # honours $BLENDER_BIN; render is skipped if the binary is missing
+  save_dir: "./outputs/custom_rig"
+  fps: 15
+  export_gt_mesh: false
+  export_gt_video: false

--- a/examples/custom_rig/run.sh
+++ b/examples/custom_rig/run.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Preprocess your own rigged FBX into everything inference needs.
+#
+# This is the mesh-free path through preprocess/run_pipeline.sh: stages 1-10
+# plus 14b, skipping the four stages that require per-character animated meshes.
+# See examples/custom_rig/README.md for the full walkthrough.
+#
+# Usage:
+#   export BLENDER=/path/to/blender
+#   export PYTHON=/path/to/python          # the torch env, NOT Blender's bundled one
+#   bash examples/custom_rig/run.sh MyRig
+#
+# Environment:
+#   BLENDER        Blender 3.6+ binary                        (default: blender)
+#   PYTHON         python with torch                          (default: python)
+#   DATA_ROOT      where your <RIG>/ FBX folder lives         (default: Truebone_Z-OO)
+#   ZOO_ROOT       where processed data is written            (default: zoo)
+#   VIDEO_ROOT     where <RIG>#clip.mp4 lives                 (default: videos)
+#   ALIGN_REF_DIR  optional dir holding <RIG>/front.npy to override the
+#                  inferred facing direction
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+RIG="${1:-}"
+if [[ -z "$RIG" ]]; then
+    echo "Usage: bash examples/custom_rig/run.sh <RIG_NAME>"
+    echo "  where \$DATA_ROOT/<RIG_NAME>/ holds your FBX files."
+    exit 1
+fi
+
+DATA_ROOT="${DATA_ROOT:-Truebone_Z-OO}"
+ZOO_ROOT="${ZOO_ROOT:-zoo}"
+VIDEO_ROOT="${VIDEO_ROOT:-videos}"
+BLENDER="${BLENDER:-blender}"
+PYTHON="${PYTHON:-python}"
+
+# ---- checks up front: every one of these fails silently or confusingly later ----
+
+if [[ ! -d "$DATA_ROOT/$RIG" ]]; then
+    echo "[ERROR] $DATA_ROOT/$RIG does not exist."
+    echo "        Put your FBX files there, e.g. $DATA_ROOT/$RIG/$RIG.fbx"
+    exit 1
+fi
+
+# No -type f here: the FBX may well be a symlink into a read-only dataset mount.
+if [[ -z "$(find -L "$DATA_ROOT/$RIG" -iname '*.fbx' -print -quit)" ]]; then
+    echo "[ERROR] No .fbx found under $DATA_ROOT/$RIG."
+    exit 1
+fi
+
+if ! compgen -G "$VIDEO_ROOT/$RIG#*" >/dev/null; then
+    echo "[ERROR] No input clip matching $VIDEO_ROOT/$RIG#* ."
+    echo "        Inference resolves the reference skeleton from the part before"
+    echo "        '#', so the clip must be named e.g. $VIDEO_ROOT/$RIG#clip.mp4"
+    exit 1
+fi
+
+if ! command -v "$BLENDER" >/dev/null 2>&1 && [[ ! -x "$BLENDER" ]]; then
+    echo "[ERROR] Blender not found at '$BLENDER'. Set BLENDER=/path/to/blender."
+    exit 1
+fi
+
+# The pipeline walks every folder in DATA_ROOT, not just this one. That is fine,
+# but say so rather than let it look like a hang.
+OTHER_RIGS=$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -type d ! -name "$RIG" | wc -l)
+if [[ "$OTHER_RIGS" -gt 0 ]]; then
+    echo "[NOTE] $DATA_ROOT holds $OTHER_RIGS other character folder(s); they will be"
+    echo "       processed too. Point DATA_ROOT at a folder containing only $RIG to"
+    echo "       process just this rig."
+fi
+
+echo "==> rig=$RIG  data=$DATA_ROOT  out=$ZOO_ROOT  video=$VIDEO_ROOT"
+
+# ---- preprocessing, part 1: FBX -> aligned character + motions ----
+
+STAGES="move_fbx,fix_fbx,extract_char,align_faces" \
+DATA_ROOT="$DATA_ROOT" ZOO_ROOT="$ZOO_ROOT" BLENDER="$BLENDER" PYTHON="$PYTHON" \
+ALIGN_REF_DIR="${ALIGN_REF_DIR:-}" \
+    bash preprocess/run_pipeline.sh
+
+# Gate on alignment before spending time on 12 rotations and a render. When the
+# facing direction cannot be inferred, align_character_face_zplus.py logs the
+# failure and moves on — everything downstream then silently uses the unaligned
+# motions and the result looks subtly wrong rather than failing.
+if [[ ! -f "$ZOO_ROOT/characters_face_zplus/$RIG/front.npy" ]]; then
+    echo
+    echo "[ERROR] Stage 4 could not align $RIG to +Z:"
+    echo "        $ZOO_ROOT/characters_face_zplus/$RIG/front.npy was not written."
+    if [[ -f "$ZOO_ROOT/characters_face_zplus/_align_failed.tsv" ]]; then
+        sed 's/^/        /' "$ZOO_ROOT/characters_face_zplus/_align_failed.tsv"
+    fi
+    cat <<EOF
+
+        Supply the facing direction yourself — a unit vector in the rig's own
+        coordinates pointing out of the character's front — and rerun:
+
+          mkdir -p examples/custom_rig/align_ref/$RIG
+          $PYTHON -c "import numpy as np; np.save('examples/custom_rig/align_ref/$RIG/front.npy', np.array([1.,0.,0.]))"
+          ALIGN_REF_DIR=examples/custom_rig/align_ref bash examples/custom_rig/run.sh $RIG
+
+        [1,0,0] means the character faces +X; [0,0,1] means it already faces +Z.
+EOF
+    exit 1
+fi
+
+# ---- preprocessing, part 2: rotations, poses, species info, render, embeddings ----
+
+STAGES="rotate_bvh,extract_pose,species_info,scale_cache,render_videos,extract_frames,preprocess_image_only" \
+DATA_ROOT="$DATA_ROOT" ZOO_ROOT="$ZOO_ROOT" BLENDER="$BLENDER" PYTHON="$PYTHON" \
+    bash preprocess/run_pipeline.sh
+
+# ---- did it actually produce the two files inference refuses to start without? ----
+
+SPECIES_INFO="$ZOO_ROOT/species_info_dict.npy"
+SCALE_CACHE="$ZOO_ROOT/cache/__mesh2pose1002_species_scale_cache.pkl"
+missing=0
+for f in "$SPECIES_INFO" "$SCALE_CACHE"; do
+    [[ -f "$f" ]] || { echo "[ERROR] missing: $f"; missing=1; }
+done
+[[ "$missing" -eq 0 ]] || exit 1
+
+"$PYTHON" - "$SPECIES_INFO" "$RIG" <<'PY'
+import sys
+import numpy as np
+
+info = np.load(sys.argv[1], allow_pickle=True).item()
+rig = sys.argv[2]
+if rig not in info:
+    print(f"[ERROR] '{rig}' not in species_info_dict.npy (have: {sorted(info)[:10]}...)")
+    sys.exit(1)
+entry = info[rig]
+print(f"[OK] {rig}: {len(entry['joints_name'])} joints, "
+      f"t5_embedding {np.asarray(entry['t5_embedding']).shape}")
+PY
+
+cat <<EOF
+
+Preprocessing done. Now run inference:
+
+  export BLENDER_BIN="$BLENDER"
+  $PYTHON -m inference.video2pose2rot --config examples/custom_rig/inference.yaml
+
+Results land in ./outputs/custom_rig/.
+EOF

--- a/preprocess/README.md
+++ b/preprocess/README.md
@@ -1,6 +1,8 @@
 # Preprocess
 
-End-to-end data preparation pipeline that turns a raw Truebone FBX dump into the latent + image-embed npz files consumed by training.
+End-to-end data preparation pipeline that turns a raw FBX dump into everything downstream needs: the `species_info_dict.npy` + scale cache that inference requires, and the latent + image-embed npz files consumed by training.
+
+It is not Truebones-specific — see [Bringing your own rig](#bringing-your-own-rig).
 
 ## Quick start
 
@@ -22,46 +24,59 @@ DATA_ROOT=Truebone_Z-OO ZOO_ROOT=zoo BLENDER=/opt/blender/blender PYTHON=python3
 
 ## Prerequisites
 
-- **Python** with `numpy`, `torch`, `scipy`, `tqdm`, `Pillow`, `matplotlib`, `trimesh`, `huggingface_hub`, `transformers`.
-- **Blender** (3.6+ / 4.x) on `PATH` or pointed to by `$BLENDER`. Used by stages 2, 5, 7.
-- **ffmpeg** on `PATH`. Used by stage 6.
-- **GPU + model checkpoints** for stage 10:
+- **Python** with `numpy`, `torch`, `scipy`, `tqdm`, `Pillow`, `matplotlib`, `trimesh`, `huggingface_hub`, `transformers`, `sentencepiece`.
+- **Blender** (3.6+ / 4.x) on `PATH` or pointed to by `$BLENDER`. Used by stages 2, 3, 9, 11.
+- **ffmpeg** on `PATH`. Used by stage 10.
+- **Network access on the first run of stage 7**, which downloads `t5-base` to embed joint names. Point `--t5_model` at a local copy to run offline.
+- **GPU + model checkpoints** for stage 14:
   - `checkpoints/TripoSG/` — TripoSG VAE + DINOv2 pipeline weights
-  - `checkpoints/RMBG-1.4/` — Bria background-removal weights
-- **Repository setup**: `TripoSG/` and `models/v1/video2mesh/pipeline_triposg.py` importable from the repo root.
+  - `checkpoints/RMBG-1.4/` — Bria background-removal weights (or let it fall back to `briaai/RMBG-1.4`)
+- **Repository setup** for stage 14: `TripoSG/` and `models/v1/video2mesh/pipeline_triposg.py` importable from the repo root.
+
+Stage 14b needs **neither** — it only uses the DINOv2 half of the pipeline, and loads
+`facebook/dinov2-large` directly when TripoSG is unavailable. The mesh-free path is therefore
+TripoSG-free end to end.
+
+`$PYTHON` must be the torch environment, *not* Blender's bundled interpreter. Stage 3 runs inside Blender but shells out to `$PYTHON` for the face-forward pass, which needs torch.
 
 ## Stages
 
 | # | Stage | Script | Tool | Input | Output |
 |---|---|---|---|---|---|
 | 1 | `move_fbx` | `move_fbx.sh` | bash | `Truebone_Z-OO/*/.../*.fbx` | flattened `Truebone_Z-OO/{character}/*.fbx` |
-| 2 | `extract_char` | `extract_character_from_fbx.py` | Blender | `Truebone_Z-OO/{character}/*.fbx` | `zoo/characters_fix_facezplus/{character}/{base_mesh.obj, blender_vertices.npy, skinning_weights.npy, rest.bvh, textures}` and `zoo/motions/{character}#{anim}.bvh` |
-| 3 | `rotate_bvh` | `rotate_bvh_parallel.py` | python | `zoo/motions/*.bvh` | `zoo/bvh/{motion}/y{deg}.bvh` (12 angles) |
-| 4 | `extract_pose` | `extract_bvh_pose.py` | python | `zoo/bvh/{motion}/y{deg}.bvh` | `zoo/bvh_pose/{motion}/y{deg}.npz` (positions, traj, rot6d, scale, frametime) |
-| 5 | `render_videos` | `render_bvh_videos.py` | Blender | `zoo/bvh/*/*.bvh` + `zoo/characters_fix_facezplus/{character}` | `zoo/video/{motion}/y{deg}.mp4` |
-| 6 | `extract_frames` | `video_to_images.py` | ffmpeg | `zoo/video/{motion}/y{deg}.mp4` | `zoo/image/{motion}/y{deg}/{00000.png, ...}` at 30 fps |
-| 7 | `remesh` | `remesh_meshes.py` | Blender | `zoo/anim_meshes/{character}.npz` (vertices, faces) **— see note below** | `zoo/remesh_npz/{character}.npz` (vertices, normals) |
-| 8 | `rotate_meshes` | `rotate_meshes.py` | python | `zoo/remesh_npz/{character}.npz` | `zoo/npz_remesh/{motion}/y{deg}.npz` |
-| 9 | `normalize` | `normalize_meshes.py` | python | `zoo/npz_remesh/` + `zoo/bvh_pose/` | `zoo/npz_mesh_normed/{motion}/y{deg}.npz` (per-species bbox normalization, key `vertices_normed`) |
-| 10 | `preprocess_data` | `preprocess_data.py` | python + GPU | `zoo/npz_mesh_normed/` + `zoo/image/` | `zoo/npz_train/{motion}/y{deg}.npz` (`latent`, `image_embed`) |
-| 11 | `image_only` | `extract_image_only.py` | python | `zoo/npz_train/` | `zoo/npz_train_image_only/{motion}/y{deg}.npz` (`image_embed` only) |
+| 2 | `fix_fbx` | `fix_fbx_batch.py` → `fix_fbx.py` | Blender | `Truebone_Z-OO/{character}/*.fbx` | `zoo/fixed_fbx/{character}/*.fbx` with no-weight leaf bones removed |
+| 3 | `extract_char` | `extract_character_from_fbx.py` | Blender | `zoo/fixed_fbx/{character}/*.fbx` | `zoo/characters_fix_facezplus/{character}/{base_mesh.obj, blender_vertices.npy, skinning_weights.npy, rest.bvh, {character}_ffs.bvh, textures}` and `zoo/motions/{character}#{anim}.bvh` |
+| 4 | `align_faces` | `align_character_face_zplus.py` | python | `zoo/characters_fix_facezplus/` + `zoo/motions/` | `zoo/characters_face_zplus/{character}/` (rest pose + `{character}_ffs.bvh` + `front.npy`) and `zoo/motions_face_zplus/*.bvh`, all facing +Z |
+| 5 | `rotate_bvh` | `rotate_bvh_parallel.py` | python | `zoo/motions_face_zplus/*.bvh` | `zoo/bvh/{motion}/y{deg}.bvh` (12 angles) |
+| 6 | `extract_pose` | `extract_bvh_pose.py` | python | `zoo/bvh/{motion}/y{deg}.bvh` | `zoo/bvh_pose/{motion}/y{deg}.npz` (positions, traj, rot6d, scale, frametime) |
+| 7 | `species_info` | `build_species_info.py` | python (T5) | `zoo/bvh/` + `zoo/bvh_pose/` | `zoo/species_info_dict.npy` (joint names, topology, joint-name T5 embeddings, static joints) |
+| 8 | `scale_cache` | `build_scale_cache.py` | python | `zoo/bvh_pose/` | `zoo/cache/__mesh2pose1002_species_scale_cache.pkl` |
+| 9 | `render_videos` | `render_bvh_videos_fast.py` | Blender | `zoo/bvh/*/*.bvh` + `zoo/characters_face_zplus/{character}` | `zoo/video/{motion}/y{deg}.mp4` |
+| 10 | `extract_frames` | `video_to_images.py` | ffmpeg | `zoo/video/{motion}/y{deg}.mp4` | `zoo/image/{motion}/y{deg}/{00000.png, ...}` at 30 fps |
+| 11 | `remesh` | `remesh_meshes.py` | Blender | `zoo/anim_meshes/{character}.npz` (vertices, faces) **— see note below** | `zoo/remesh_npz/{character}.npz` (vertices, normals) |
+| 12 | `rotate_meshes` | `rotate_meshes.py` | python | `zoo/remesh_npz/{character}.npz` | `zoo/npz_remesh/{motion}/y{deg}.npz` |
+| 13 | `normalize` | `normalize_meshes.py` | python | `zoo/npz_remesh/` + `zoo/bvh_pose/` | `zoo/npz_mesh_normed/{motion}/y{deg}.npz` (per-species bbox normalization, key `vertices_normed`) |
+| 14 | `preprocess_data` | `preprocess_data.py` | python + GPU | `zoo/npz_mesh_normed/` + `zoo/image/` | `zoo/npz_train/{motion}/y{deg}.npz` (`latent`, `image_embed`) |
+| 15 | `image_only` | `extract_image_only.py` | python | `zoo/npz_train/` | `zoo/npz_train_image_only/{motion}/y{deg}.npz` (`image_embed` only) |
+
+**Stages 7 and 8 produce the two files inference refuses to start without**: `species_info_dict.npy` and `cache/__mesh2pose1002_species_scale_cache.pkl`. Every inference entry point looks up the species by the prefix of the clip name and raises `KeyError` if it is not in `species_info_dict.npy`.
 
 ### Mesh-free alternative
 
-If you do not have `zoo/anim_meshes/` (stage 7 input), skip stages 7-11 and run this stage instead. It produces the same `npz_train_image_only/` artifact directly from `zoo/image/`, which is enough for the `video2pose` / `pose2rot` / `video2pose2rot` training pipelines (only `video2mesh` and `mesh2pose` truly require the mesh latent).
+If you do not have `zoo/anim_meshes/` (stage 11 input), skip stages 11-15 and run this stage instead. It produces the same `npz_train_image_only/` artifact directly from `zoo/image/`, which is enough for the `video2pose` / `pose2rot` / `video2pose2rot` pipelines (only `video2mesh` and `mesh2pose` truly require the mesh latent).
 
 | # | Stage | Script | Tool | Input | Output |
 |---|---|---|---|---|---|
-| 10b | `preprocess_image_only` | `preprocess_image_only.py` | python + GPU | `zoo/image/` | `zoo/npz_train_image_only/{motion}/y{deg}.npz` (`image_embed` only) |
+| 14b | `preprocess_image_only` | `preprocess_image_only.py` | python + GPU | `zoo/image/` | `zoo/npz_train_image_only/{motion}/y{deg}.npz` (`image_embed` only) |
 
 ```bash
-STAGES="move_fbx,extract_char,rotate_bvh,extract_pose,render_videos,extract_frames,preprocess_image_only" \
+STAGES="move_fbx,fix_fbx,extract_char,align_faces,rotate_bvh,extract_pose,species_info,scale_cache,render_videos,extract_frames,preprocess_image_only" \
     bash preprocess/run_pipeline.sh
 ```
 
 ### Fast BVH video renderer
 
-`render_bvh_videos_fast.py` is a drop-in faster renderer for stage 5. It keeps the same dataset layout as the original renderer:
+`render_bvh_videos_fast.py` is what stage 9 runs; `render_bvh_videos.py` is the original, slower renderer. Both keep the same dataset layout:
 
 ```text
 zoo/video/{motion}/y{deg}.mp4
@@ -72,9 +87,13 @@ Example:
 ```bash
 BLENDER=/opt/blender/blender python preprocess/render_bvh_videos_fast.py \
     --zoo-root zoo \
+    --character-root zoo/characters_face_zplus \
     --workers 4 \
     --views y0,y30,y60,y90,y120,y150,y180,y210,y240,y270,y300,y330
 ```
+
+`--character-root` defaults to `zoo/characters_fix_facezplus`. Pass `characters_face_zplus`
+(as stage 9 does) once stage 4 has run, or the rendered mesh will not match the BVH orientation.
 
 The speedup comes from four changes:
 
@@ -99,15 +118,23 @@ BLENDER=/opt/blender/blender python preprocess/benchmark_render_bvh_videos.py \
 
 ```
 zoo/
+├── fixed_fbx/{Character}/*.fbx            # no-weight leaf bones removed
 ├── characters_fix_facezplus/
 │   └── {Character}/
 │       ├── base_mesh.obj / .mtl / textures
 │       ├── blender_vertices.npy
 │       ├── skinning_weights.npy
-│       └── rest.bvh
+│       ├── rest.bvh
+│       └── {Character}_ffs.bvh            # face-forward, scale 0.01 — mesh export template
+├── characters_face_zplus/{Character}/     # same contents, rotated to face +Z, plus front.npy
 ├── motions/{character}#{anim}.bvh
+├── motions_face_zplus/{character}#{anim}.bvh
 ├── bvh/{motion}/y{deg}.bvh                # 12 rotations
 ├── bvh_pose/{motion}/y{deg}.npz           # positions, traj, rot6d, scale
+├── species_info_dict.npy                  # REQUIRED BY INFERENCE — topology + joint-name T5 embeddings
+├── joint_name_map.json                    # optional input to stage 7, see below
+├── cache/
+│   └── __mesh2pose1002_species_scale_cache.pkl   # REQUIRED BY INFERENCE
 ├── video/{motion}/y{deg}.mp4
 ├── image/{motion}/y{deg}/00000.png ...
 ├── anim_meshes/{character}.npz            # YOU PROVIDE: vertices (T,N,3) + faces
@@ -116,6 +143,68 @@ zoo/
 ├── npz_mesh_normed/{motion}/y{deg}.npz    # vertices_normed, bbox_center, global_scale
 ├── npz_train/{motion}/y{deg}.npz          # latent + image_embed
 └── npz_train_image_only/{motion}/y{deg}.npz
+```
+
+## Bringing your own rig
+
+Everything above works on any rigged FBX, not just the Truebones dump. The short
+version — see [`../examples/custom_rig/README.md`](../examples/custom_rig/README.md)
+for the walkthrough, including a worked end-to-end example.
+
+```bash
+Truebone_Z-OO/MyRig/MyRig.fbx      # base: mesh + skeleton (shortest filename wins)
+Truebone_Z-OO/MyRig/MyRig-Walk.fbx # one or more motions
+videos/MyRig#clip.mp4              # your footage; the prefix before '#' must match the rig folder
+
+export BLENDER=/path/to/blender PYTHON=/path/to/torch/python
+bash examples/custom_rig/run.sh MyRig
+python -m inference.video2pose2rot --config examples/custom_rig/inference.yaml
+```
+
+Two stages guess things about your rig and **neither raises an error when the guess is wrong**:
+
+- **Stage 4** infers which way the character faces. If the mesh comes out rotated in the
+  output video while the skeleton looks fine, drop a `front.npy` (unit vector pointing out
+  of the character's front, in rig coordinates) into `$ALIGN_REF_DIR/{Character}/` and rerun.
+- **Stage 2** deletes leaf bones that carry no skin weights, because that is what the
+  released datasets were built with (3ds Max Biped `*Nub` bones). If your rig has meaningful
+  weightless leaves, drop `fix_fbx` from `STAGES`.
+
+### Joint names and `joint_name_map.json`
+
+Stage 7 embeds each joint's *name* with T5, and the model uses those embeddings to reason
+about what each joint is. This is the only place the two released datasets differ:
+
+| Dataset | How `rename_clean` is produced |
+|---|---|
+| `obj1k` | automatic cleanup (`mixamorig:LeftUpLeg` → `Left Up Leg`) — no map file needed |
+| `zoo1030` | curated canonical names (`quadruped spine 01`, `flyer tail 01`) supplied via `joint_name_map.json` |
+
+Without a map, stage 7 falls back to automatic cleanup and prints a warning. That is correct
+and self-consistent for a new rig, but the resulting embeddings will not match the curated
+`zoo1030` convention. To use curated names, hand-write the mapping — the file is
+`{"MyRig": {"<bone name in the FBX>": "<readable name>", ...}}` — and pass it in:
+
+```bash
+python preprocess/build_species_info.py --dataset_root zoo --joint_name_map path/to/joint_name_map.json
+```
+
+Note that trailing digits are stripped during automatic cleanup, so `Tail_01 … Tail_07`
+collapse to a single `Tail` embedding. Spell ordinals out if they matter for your rig.
+
+To dump the mapping out of an existing `species_info_dict.npy` (e.g. to see the convention
+the released data uses):
+
+```bash
+python preprocess/build_species_info.py --export_map_from datasets/zoo1030/species_info_dict.npy --output joint_name_map.json
+```
+
+To check a rebuild against released data without writing anything:
+
+```bash
+python preprocess/build_species_info.py --dataset_root datasets/zoo1030 \
+    --joint_name_map joint_name_map.json \
+    --verify_against datasets/zoo1030/species_info_dict.npy
 ```
 
 ## Configuration
@@ -127,13 +216,17 @@ The runner reads these env vars (defaults shown):
 | `DATA_ROOT` | `Truebone_Z-OO` | folder of raw character FBX folders |
 | `ZOO_ROOT` | `zoo` | output root for every intermediate + final artifact |
 | `BLENDER` | `blender` | Blender executable |
-| `PYTHON` | `python` | Python interpreter |
+| `PYTHON` | `python` | Python interpreter (must have torch) |
 | `STAGES` | `all` | comma-separated stage names to run |
+| `ALIGN_REF_DIR` | *(unset)* | folder of `{Character}/front.npy` overrides for stage 4 |
+| `BVH_SRC` | *(auto)* | stage 5 source; defaults to `motions_face_zplus/` when it exists, else `motions/` |
 
 Individual scripts also accept `--input_root` / `--output_root` / `--num_workers` etc. — see each script's `argparse` block.
 
 ## Notes & caveats
 
-- **Stage 7 (`remesh`) needs `zoo/anim_meshes/{character}.npz`** containing per-frame deformed vertices (`vertices` shape `(T, N, 3)`) and shared `faces` (`(F, 3)`). The pipeline does **not** generate this — it's the LBS / skinning step that applies the per-frame BVH pose to `base_mesh.obj` using `skinning_weights.npy`. Drop your own script in, or ping me to add one. The runner will fail with a clear error if this folder is missing.
-- **Per-species normalization**: stage 9 collects every motion of a species (`Alligator#*`) and computes one shared bbox center + global scale, so meshes stay comparable across motions. It depends on stage 4's `bvh_pose` output for the root trajectory.
-- **Sharded GPU run** for stage 10: launch the same command on N GPUs with `--shard 0..N-1 --num_shards N` to split the workload.
+- **Stage 11 (`remesh`) needs `zoo/anim_meshes/{character}.npz`** containing per-frame deformed vertices (`vertices` shape `(T, N, 3)`) and shared `faces` (`(F, 3)`). The pipeline does **not** generate this — it's the LBS / skinning step that applies the per-frame BVH pose to `base_mesh.obj` using `skinning_weights.npy`. Drop your own script in, or ping me to add one. The runner will fail with a clear error if this folder is missing.
+- **Per-species normalization**: stage 13 collects every motion of a species (`Alligator#*`) and computes one shared bbox center + global scale, so meshes stay comparable across motions. It depends on stage 6's `bvh_pose` output for the root trajectory.
+- **Sharded GPU run** for stage 14: launch the same command on N GPUs with `--shard 0..N-1 --num_shards N` to split the workload.
+- **`{Character}_ffs.bvh` is not optional.** It is the rest-pose template `utils/npy2bvh.py` writes predicted rotations against, at scale 0.01. Stage 3 writes it and stage 4 rewrites it from the aligned rest pose. A stale or hand-copied one produces a collapsed or 90°-rotated mesh in the output video with no error message.
+- **Stage 7 keeps only the majority skeleton** when one species has several rig variants across its motions, matching how the released `species_info_dict.npy` was built.

--- a/preprocess/align_character_face_zplus.py
+++ b/preprocess/align_character_face_zplus.py
@@ -1,0 +1,211 @@
+import argparse
+import os
+import sys
+from glob import glob
+
+import numpy as np
+from tqdm import tqdm
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import utils.bvh as BVH
+from utils.bvh_tools import (
+    face_forward_bvh_with_scale,
+    quadruped_character_restpose_alignment,
+)
+
+
+INVERSE_LIST = {
+    # "Anaconda",
+    "Goat",
+    "Jaws",
+    "Raptor3",
+    "Scorpion",
+    "Scorpion-2",
+    "Spider",
+    # "Tukan",
+    "Raptor2",
+    "Trex",
+}
+
+MANUALLY_DEFINED = {
+    "Crab": [1, 0, 0],
+    "Deer": [0, 0, -1],
+    "Dog": [0, 0, -1],
+    "Dog-2": [0, 0, -1],
+    "Giantbee": [1, 0, 0],
+    "HermitCrab": [1, 0, 0],
+    "Parrot": [1, 0, 0],
+    "Parrot2": [1, 0, 0],
+    "Pirrana": [1, 0, 0],
+    "SabreToothTiger": [0, 0, -1],
+    "Tyranno": [1, 0, 0],
+    "KingCobra": [1, 0, 0],
+    "Buffalo": [1, 0, 0],
+}
+
+
+def resolve_front(character_name, ref_dir):
+    if character_name in MANUALLY_DEFINED:
+        return np.asarray(MANUALLY_DEFINED[character_name], dtype=np.float64)
+
+    if ref_dir:
+        ref_path = os.path.join(ref_dir, character_name, "front.npy")
+        if os.path.exists(ref_path):
+            front = np.load(ref_path).astype(np.float64)
+            if character_name in INVERSE_LIST:
+                front = -front
+            return front
+
+    # Let quadruped_character_restpose_alignment infer and save front.npy.
+    # For inverse-list species without an external reference, we apply the
+    # inversion after an initial inferred pass in align_one().
+    return None
+
+
+def find_rest_bvh(character_folder):
+    preferred = os.path.join(character_folder, "rest.bvh")
+    if os.path.exists(preferred):
+        return preferred
+    candidates = sorted(glob(os.path.join(character_folder, "*.bvh")))
+    return candidates[0] if candidates else None
+
+
+def face_forward_in_place(bvh_path):
+    anim, names, frametime = BVH.load(bvh_path)
+    face_forward_bvh_with_scale(bvh_path, anim, names, frametime)
+
+
+def write_ffs_bvh(character_name, target_dir, rest_bvh_path, scale=0.01):
+    """Regenerate `{character}_ffs.bvh` from the ALIGNED rest pose.
+
+    extract_character_from_fbx.py already wrote one next to the unaligned rest
+    pose, and it gets copied here verbatim — so it has to be rebuilt, or the mesh
+    export ends up 90 degrees off from everything else.
+    """
+    ffs_path = os.path.join(target_dir, f"{character_name}_ffs.bvh")
+    anim, names, frametime = BVH.load(rest_bvh_path)
+    face_forward_bvh_with_scale(ffs_path, anim, names, frametime, scale)
+    return ffs_path
+
+
+def align_motion_bvhs(character_name, front, motion_root, motion_output_root, skip_existing=True):
+    motion_paths = sorted(glob(os.path.join(motion_root, f"{character_name}#*.bvh")))
+    os.makedirs(motion_output_root, exist_ok=True)
+    done = 0
+    skipped = 0
+    for motion_bvh in motion_paths:
+        out_bvh = os.path.join(motion_output_root, os.path.basename(motion_bvh))
+        if skip_existing and os.path.exists(out_bvh):
+            skipped += 1
+            continue
+        quadruped_character_restpose_alignment(motion_bvh, motion_output_root, front=front)
+        done += 1
+    return done, skipped
+
+
+def align_one(
+    character_folder,
+    output_root,
+    motion_root=None,
+    motion_output_root=None,
+    ref_dir=None,
+    skip_existing=True,
+):
+    character_name = os.path.basename(character_folder.rstrip(os.sep))
+    target_dir = os.path.join(output_root, character_name)
+    target_bvh = os.path.join(target_dir, "rest.bvh")
+
+    rest_bvh = find_rest_bvh(character_folder)
+    if rest_bvh is None:
+        raise FileNotFoundError(f"No rest BVH found in {character_folder}")
+
+    os.makedirs(target_dir, exist_ok=True)
+    front = resolve_front(character_name, ref_dir)
+
+    character_ready = (
+        skip_existing
+        and os.path.exists(target_bvh)
+        and os.path.exists(os.path.join(target_dir, "base_mesh.obj"))
+        and os.path.exists(os.path.join(target_dir, "front.npy"))
+    )
+    if character_ready:
+        front = np.load(os.path.join(target_dir, "front.npy")).astype(np.float64)
+        char_status = "SKIP"
+    else:
+        if front is None and character_name in INVERSE_LIST:
+            # Infer once, read front.npy, then rerun with inverted front.
+            quadruped_character_restpose_alignment(rest_bvh, target_dir, front=None)
+            inferred_front_path = os.path.join(target_dir, "front.npy")
+            front = -np.load(inferred_front_path).astype(np.float64)
+
+        quadruped_character_restpose_alignment(rest_bvh, target_dir, front=front)
+        front = np.load(os.path.join(target_dir, "front.npy")).astype(np.float64)
+
+        aligned_bvh = os.path.join(target_dir, os.path.basename(rest_bvh))
+        if os.path.basename(rest_bvh) != "rest.bvh":
+            os.replace(aligned_bvh, target_bvh)
+            aligned_bvh = target_bvh
+        face_forward_in_place(aligned_bvh)
+        write_ffs_bvh(character_name, target_dir, aligned_bvh)
+        char_status = "DONE"
+
+    motion_status = ""
+    if motion_root and motion_output_root:
+        done, skipped = align_motion_bvhs(
+            character_name,
+            front,
+            motion_root,
+            motion_output_root,
+            skip_existing=skip_existing,
+        )
+        motion_status = f", motions done={done}, skip={skipped}"
+    return f"[{char_status}] {character_name}{motion_status}"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input_root", default=os.path.join(os.environ.get("ZOO_ROOT", "zoo"), "characters"))
+    parser.add_argument("--output_root", default=os.path.join(os.environ.get("ZOO_ROOT", "zoo"), "characters_face_zplus"))
+    parser.add_argument("--motion_root", default=os.path.join(os.environ.get("ZOO_ROOT", "zoo"), "motions"))
+    parser.add_argument("--motion_output_root", default=os.path.join(os.environ.get("ZOO_ROOT", "zoo"), "motions_face_zplus"))
+    parser.add_argument("--ref_dir", default=os.environ.get("ALIGN_REF_DIR", ""))
+    parser.add_argument("--no_skip_existing", action="store_true")
+    args = parser.parse_args()
+
+    character_folders = sorted(
+        path for path in glob(os.path.join(args.input_root, "*")) if os.path.isdir(path)
+    )
+    # Optional sharding for parallel runs (obj1k speedup). Env-gated.
+    _si = int(os.environ.get('SHARD_IDX', '0'))
+    _st = int(os.environ.get('SHARD_TOTAL', '1'))
+    if _st > 1:
+        character_folders = [d for i, d in enumerate(character_folders) if i % _st == _si]
+    print(f"==> Aligning {len(character_folders)} characters to +Z")
+    failures = []
+    for character_folder in tqdm(character_folders, desc="align_characters"):
+        character_name = os.path.basename(character_folder.rstrip(os.sep))
+        try:
+            print(align_one(
+                character_folder,
+                args.output_root,
+                motion_root=args.motion_root,
+                motion_output_root=args.motion_output_root,
+                ref_dir=args.ref_dir or None,
+                skip_existing=not args.no_skip_existing,
+            ))
+        except Exception as exc:
+            failures.append((character_name, str(exc)))
+            print(f"[ERROR] {character_name}: {exc}")
+
+    if failures:
+        failed_path = os.path.join(args.output_root, "_align_failed.tsv")
+        os.makedirs(args.output_root, exist_ok=True)
+        with open(failed_path, "w") as f:
+            for character_name, error in failures:
+                f.write(f"{character_name}\t{error}\n")
+        print(f"[WARN] Alignment failures written to {failed_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess/build_scale_cache.py
+++ b/preprocess/build_scale_cache.py
@@ -1,0 +1,110 @@
+"""
+Build the per-species scale cache pickle consumed by loader_v2 / species_fps_memory.
+
+Scale definition (matches how the loader normalizes):
+    pos_rel   = position - position[:, 0:1, :]      # root-relative point cloud
+    global_scale = max(|pos_rel|) over all frames/joints/xyz of the species
+    => pos_rel / global_scale lies within [-1, +1]  (bbox fits the unit cube)
+
+Output pickle format:
+    { species_name: {"global_scale": float, "bbox_center": np.array([0,0,0], float32)} }
+
+bbox_center is stored as zeros (the cloud is already root-centered); loader_v2 only
+reads global_scale, species_fps_memory reads global_scale (+ optional bbox_center).
+"""
+
+import os
+import glob
+import pickle
+import argparse
+from collections import defaultdict
+
+import numpy as np
+from tqdm import tqdm
+
+EPS = 1e-6
+
+
+POS_FIELD = "position"  # overridden by --pos_field
+
+def safe_load_positions(npz_path):
+    """Return root-relative position [F, J, 3], or None if empty/corrupt."""
+    try:
+        if os.path.getsize(npz_path) == 0:
+            return None
+        data = np.load(npz_path)
+        pos = data[POS_FIELD].astype(np.float64)          # [F, J, 3]
+        if pos.ndim != 3 or pos.shape[0] == 0:
+            return None
+        return pos - pos[:, 0:1, :]                       # root-relative
+    except Exception as e:
+        print(f"  ⚠️ skip unreadable npz: {npz_path} ({e})")
+        return None
+
+
+def collect_by_species(bvh_pose_root):
+    species_dirs = defaultdict(list)
+    for name in sorted(os.listdir(bvh_pose_root)):
+        full = os.path.join(bvh_pose_root, name)
+        if os.path.isdir(full) and "#" in name:
+            species_dirs[name.split("#")[0]].append(full)
+    return species_dirs
+
+
+def species_global_scale(seq_dirs):
+    """max abs coordinate of root-relative positions across all valid npz."""
+    max_abs = 0.0
+    n_used = 0
+    for d in seq_dirs:
+        for p in sorted(glob.glob(os.path.join(d, "*.npz"))):
+            pos_rel = safe_load_positions(p)
+            if pos_rel is None:
+                continue
+            m = float(np.abs(pos_rel).max())
+            if m > max_abs:
+                max_abs = m
+            n_used += 1
+    return max_abs, n_used
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bvh_pose_root", default=os.path.join(os.environ.get("ZOO_ROOT", "zoo"), "bvh_pose"))
+    ap.add_argument("--output", default=os.path.join(
+        os.environ.get("ZOO_ROOT", "zoo"), "cache", "__mesh2pose1002_species_scale_cache.pkl"))
+    ap.add_argument("--pos_field", default="position",
+                    help="field to measure; use position_before to match a raw_position loader")
+    args = ap.parse_args()
+
+    global POS_FIELD
+    POS_FIELD = args.pos_field
+    print(f"[INFO] pos_field = {POS_FIELD}")
+
+    species_dirs = collect_by_species(args.bvh_pose_root)
+    scale_dict = {}
+    skipped = []
+
+    for sp in tqdm(sorted(species_dirs), desc="scale cache"):
+        max_abs, n_used = species_global_scale(species_dirs[sp])
+        if n_used == 0 or max_abs < EPS:
+            skipped.append((sp, f"no valid pose (n_used={n_used}, max_abs={max_abs:.3g})"))
+            continue
+        scale_dict[sp] = {
+            "global_scale": float(max_abs),
+            "bbox_center": np.zeros(3, dtype=np.float32),
+        }
+        print(f"  {sp:<16} global_scale={max_abs:.6f}  (npz used={n_used})")
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)) or ".", exist_ok=True)
+    with open(args.output, "wb") as f:
+        pickle.dump(scale_dict, f)
+
+    print(f"\n✅ wrote scale cache for {len(scale_dict)} species -> {args.output}")
+    if skipped:
+        print(f"⚠️ skipped {len(skipped)} species (no usable pose):")
+        for sp, why in skipped:
+            print(f"   {sp}: {why}")
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess/build_species_info.py
+++ b/preprocess/build_species_info.py
@@ -1,0 +1,472 @@
+"""Build `species_info_dict.npy` from a preprocessed dataset root.
+
+Consumes the stage-3 / stage-4 artifacts (`bvh/` and `bvh_pose/`) and produces the
+per-species static info that training and inference load:
+
+    joints_name       list[str], length J          BVH hierarchy order
+    joints_distance   (J, J) float64               tree-hop distance, capped at max_path_len
+    joint_relation    (J, J) float64               edge-type id (see EDGE_TYPES)
+    rename_clean      list[str], length J          human-readable joint name fed to T5
+    t5_embedding      (J, 768) float32             mean-pooled t5-base encoding of rename_clean
+    static_joints     list[int]                    joints that never translate (root-relative)
+    static_rot_joints list[int]                    joints that never rotate
+
+`rename_clean` is either looked up in a per-species joint-name map (`--joint_name_map`)
+or derived automatically from the raw BVH joint names. The zoo1030 release uses curated
+canonical names ("quadruped spine 01") that cannot be derived from the raw names, so it
+needs the map; obj1k was built with the automatic path and reproduces exactly without one.
+
+Usage:
+    # build
+    python preprocess/build_species_info.py --dataset_root <root> [--joint_name_map map.json]
+
+    # verify a rebuild against an existing file without writing anything
+    python preprocess/build_species_info.py --dataset_root <root> \
+        --joint_name_map map.json --verify_against <root>/species_info_dict.npy --sample 10
+
+    # export the orig -> canonical map out of an existing species_info_dict.npy
+    python preprocess/build_species_info.py --export_map_from <root>/species_info_dict.npy \
+        --output joint_name_map.json
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, OrderedDict, defaultdict
+from glob import glob
+
+import numpy as np
+from tqdm import tqdm
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils import bvh as BVH
+
+
+EDGE_TYPES = {
+    'self':          0,
+    'parent':        1,
+    'child':         2,
+    'sibling':       3,
+    'no_relation':   4,
+    'end_effector':  5,
+    'ts_token_conn': 6,
+}
+
+# A joint is static when its speed stays below this for every frame of every sequence.
+STATIC_EPS = 1e-6
+
+# `static_joints` is measured on the four cardinal yaws only; `static_rot_joints` on all of them.
+POS_YAWS = {'y0.npz', 'y90.npz', 'y180.npz', 'y270.npz'}
+
+
+# --------------------------------------------------------------------------- topology
+
+def create_topology_edge_relations(parents, max_path_len=5):
+    """Build (edge_rel, topo_rel) for a skeleton given its `parents` array.
+
+    parents : array-like of int, length J. parents[0] is typically -1.
+    """
+    n = len(parents)
+    topo_rel = np.zeros((n, n), dtype=np.float64)
+    edge_rel = np.full((n, n), EDGE_TYPES['no_relation'], dtype=np.float64)
+
+    for i in range(n):
+        parent_i = parents[i]
+        is_ee = True
+        for j in range(n):
+            parent_j = parents[j]
+
+            # --- edge type ---
+            if i == j:
+                edge_rel[i, j] = EDGE_TYPES['self']
+            elif parent_j == i:                # j is a child of i
+                edge_rel[i, j] = EDGE_TYPES['child']
+                is_ee = False
+            elif j == parent_i:                # j is the parent of i
+                edge_rel[i, j] = EDGE_TYPES['parent']
+            elif parent_j == parent_i:         # same parent => sibling
+                edge_rel[i, j] = EDGE_TYPES['sibling']
+            # else: stays no_relation
+
+            # --- tree-hop distance ---
+            if i == j:
+                topo_rel[i, j] = 0
+            elif j < i:                        # symmetric, reuse
+                topo_rel[i, j] = topo_rel[j, i]
+            elif parent_j == i:
+                topo_rel[i, j] = 1
+            else:
+                topo_rel[i, j] = topo_rel[i, parent_j] + 1
+
+        if is_ee:
+            edge_rel[i, i] = EDGE_TYPES['end_effector']
+
+    topo_rel[topo_rel > max_path_len] = max_path_len
+    return edge_rel, topo_rel
+
+
+def species_from_path(path):
+    """`bvh/Alligator#AlligatorALL-Bite1/y0.bvh` -> `Alligator`."""
+    stem = os.path.splitext(os.path.basename(path))[0]
+    if '#' in stem:
+        return stem.split('#', 1)[0]
+    parent = os.path.basename(os.path.dirname(path))
+    if '#' in parent:
+        return parent.split('#', 1)[0]
+    return stem
+
+
+def collect_skeletons(bvh_root, max_path_len=5, verbose=True):
+    """One skeleton per species. When a species has several rig variants across its
+    sequences, pick the MAJORITY skeleton rather than whichever file sorts first."""
+    # One yaw per sequence is enough: rotating a BVH never changes its hierarchy.
+    paths = sorted(glob(os.path.join(bvh_root, '*#*', 'y0.bvh')))
+    if not paths:
+        paths = sorted(glob(os.path.join(bvh_root, '**', '*.bvh'), recursive=True))
+    if not paths:
+        raise SystemExit(f'No .bvh files found under {bvh_root}')
+
+    by_species = defaultdict(list)
+    for p in paths:
+        by_species[species_from_path(p)].append(p)
+
+    out = OrderedDict()
+    iterator = sorted(by_species)
+    if verbose:
+        iterator = tqdm(iterator, desc='skeletons')
+
+    for species in iterator:
+        sig_count = Counter()
+        sig_data = {}
+        for bvh_pth in by_species[species]:
+            try:
+                anim, names, _ = BVH.load(bvh_pth)
+            except Exception:
+                continue
+            sig = tuple(names)
+            sig_count[sig] += 1
+            if sig not in sig_data:
+                sig_data[sig] = (list(names), np.asarray(anim.parents))
+
+        if not sig_count:
+            print(f'[skip] {species}: no readable BVH')
+            continue
+
+        best_sig, best_n = sig_count.most_common(1)[0]
+        if len(sig_count) > 1:
+            print(f'[multi-rig] {species}: {len(sig_count)} skeletons '
+                  f'{[(len(s), c) for s, c in sig_count.most_common()]}, '
+                  f'using J={len(best_sig)} (n={best_n})')
+
+        names, parents = sig_data[best_sig]
+        # BVH `ROOT __0` is a placeholder name; the released files call it Root.
+        names = ['Root' if n == '__0' else n for n in names]
+        edge_rel, topo_rel = create_topology_edge_relations(parents, max_path_len=max_path_len)
+        out[species] = {
+            'joints_name':     names,
+            'joints_distance': topo_rel,
+            'joint_relation':  edge_rel,
+        }
+
+    return out
+
+
+# ------------------------------------------------------------------- joint name cleanup
+
+REMOVE_PREFIXES = ['BN_Bip01', 'Bip01', 'BN', 'NPC', 'jt', 'Sabrecat', 'Elk',
+                   'mixamorig:', 'mixamorig']
+JAPANESE_WORDS = {
+    'momo': 'Thigh', 'sippo': 'Tail', 'mune': 'Chest', 'hiza': 'Knee', 'hara': 'Stomach',
+    'ashi': 'Leg', 'hiji': 'Elbow', 'koshi': 'Hips', 'te': 'Hand', 'kubi': 'Neck',
+    'atama': 'Head', 'ago': 'Jaw', 'kata': 'Shoulder',
+}
+
+
+def _remove_prefix(s):
+    orig = s
+    for prefix in REMOVE_PREFIXES:
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+    return s or orig
+
+
+def _split_and_replace(s):
+    new_splitted = []
+    for part in re.split('(?=[A-Z]|_)', s):
+        clean = re.sub(r'[\d_]+', '', part)
+        if clean == '':
+            continue
+        elif clean in ('L', 'l'):
+            new_splitted.append('Left')
+        elif clean in ('R', 'r'):
+            new_splitted.append('Right')
+        elif clean in JAPANESE_WORDS:
+            new_splitted.append(JAPANESE_WORDS[clean])
+        elif clean == 'Tai':
+            new_splitted.append('Tail')
+        else:
+            new_splitted.append(clean)
+    return ' '.join(new_splitted) if new_splitted else s
+
+
+def auto_clean(name):
+    """Strip rig prefixes and split CamelCase/underscores into words T5 can read."""
+    return _split_and_replace(_remove_prefix(name)) if name else ''
+
+
+def canonical_names(species, joints_name, name_map):
+    """Look joint names up in `name_map[species]`, falling back to `auto_clean`."""
+    if not name_map:
+        return [auto_clean(n) for n in joints_name], 0
+    per_species = name_map.get(species, {})
+    out, missing = [], 0
+    for n in joints_name:
+        if n in per_species:
+            out.append(per_species[n])
+        else:
+            missing += 1
+            out.append(auto_clean(n))
+    return out, missing
+
+
+# ------------------------------------------------------------------------------- T5
+
+def make_t5_encoder(model_name='t5-base', device=None):
+    """Mean-pool t5-base over the joint-name tokens, masking padding and empty names."""
+    import torch
+    from transformers import T5EncoderModel, T5Tokenizer
+
+    device = device or ('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f'Loading T5 encoder: {model_name} on {device}')
+    tokenizer = T5Tokenizer.from_pretrained(model_name)
+    encoder = T5EncoderModel.from_pretrained(model_name).to(device).eval()
+
+    def embed(entries):
+        inputs = tokenizer(entries, return_tensors='pt', padding=True, truncation=True).to(device)
+        mask = inputs['attention_mask'].clone()
+        for i, e in enumerate(entries):
+            if e == '':
+                mask[i] = 0
+        with torch.no_grad():
+            out = encoder(**inputs).last_hidden_state
+            pooled = (out * mask.unsqueeze(-1)).sum(1) / mask.sum(1, keepdim=True).clamp(min=1)
+        return pooled.float().cpu().numpy()
+
+    return embed
+
+
+# ---------------------------------------------------------------------------- static
+
+def static_indices(files, key, subtract_traj):
+    """Indices of joints whose per-frame speed never exceeds STATIC_EPS."""
+    cat, num_joints = [], None
+    for f in files:
+        try:
+            data = np.load(f)
+        except Exception:
+            continue
+        if key not in data:
+            continue
+        a = data[key]
+        if a.ndim != 3 or a.shape[0] == 0:
+            continue
+        if subtract_traj and 'traj' in data:
+            a = a - data['traj'][:, None, :]        # root-relative
+        if num_joints is None:
+            num_joints = a.shape[1]
+        elif a.shape[1] != num_joints:
+            continue
+        cat.append(a)
+
+    if not cat:
+        return []
+    cat = np.concatenate(cat, 0)
+    if cat.shape[0] < 2:
+        return list(range(cat.shape[1]))
+    speed = np.linalg.norm(np.diff(cat, axis=0), axis=-1)     # [T-1, J]
+    return np.where((speed < STATIC_EPS).all(axis=0))[0].tolist()
+
+
+def species_static(pose_root, species):
+    all_npz = sorted(glob(os.path.join(pose_root, f'{species}#*', 'y*.npz')))
+    cardinal = [f for f in all_npz if os.path.basename(f) in POS_YAWS]
+    return (static_indices(cardinal, 'position', subtract_traj=True),
+            static_indices(all_npz, 'rot6d', subtract_traj=False))
+
+
+# ----------------------------------------------------------------------------- build
+
+def build(dataset_root, name_map=None, t5_model='t5-base', max_path_len=5,
+          device=None, only_species=None):
+    bvh_root = os.path.join(dataset_root, 'bvh')
+    pose_root = os.path.join(dataset_root, 'bvh_pose')
+
+    skeletons = collect_skeletons(bvh_root, max_path_len=max_path_len)
+    if only_species is not None:
+        skeletons = OrderedDict((s, v) for s, v in skeletons.items() if s in only_species)
+    print(f'{len(skeletons)} species')
+
+    embed = make_t5_encoder(t5_model, device=device)
+
+    total_missing = 0
+    out = OrderedDict()
+    for species, info in tqdm(skeletons.items(), total=len(skeletons), desc='species_info'):
+        rename_clean, missing = canonical_names(species, info['joints_name'], name_map)
+        total_missing += missing
+        static_pos, static_rot = species_static(pose_root, species)
+        out[species] = {
+            'joints_name':       info['joints_name'],
+            'joints_distance':   info['joints_distance'],
+            'joint_relation':    info['joint_relation'],
+            'rename_clean':      rename_clean,
+            't5_embedding':      embed(rename_clean).astype(np.float32),
+            'static_joints':     static_pos,
+            'static_rot_joints': static_rot,
+        }
+
+    if name_map and total_missing:
+        print(f'[warn] {total_missing} joints were absent from the name map and fell back '
+              f'to automatic cleanup')
+    return out
+
+
+# ---------------------------------------------------------------------------- verify
+
+def cosine_rows(a, b):
+    num = (a * b).sum(1)
+    den = np.linalg.norm(a, axis=1) * np.linalg.norm(b, axis=1)
+    den = np.where(den == 0, 1.0, den)
+    return num / den
+
+
+def verify(built, reference, min_cosine=0.9999, max_abs=1e-2):
+    exact_fields = ['joints_name', 'joints_distance', 'joint_relation',
+                    'rename_clean', 'static_joints', 'static_rot_joints']
+    failures = []
+    worst_cos, worst_abs = 1.0, 0.0
+
+    for species, got in sorted(built.items()):
+        if species not in reference:
+            failures.append((species, 'missing', 'not in reference'))
+            continue
+        ref = reference[species]
+        for field in exact_fields:
+            a, b = got[field], ref[field]
+            if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
+                same = np.array_equal(np.asarray(a), np.asarray(b))
+            else:
+                same = [str(x) for x in a] == [str(x) for x in b]
+            if not same:
+                failures.append((species, field, f'{_brief(a)} != {_brief(b)}'))
+
+        a, b = np.asarray(got['t5_embedding'], np.float64), np.asarray(ref['t5_embedding'], np.float64)
+        if a.shape != b.shape:
+            failures.append((species, 't5_embedding', f'shape {a.shape} != {b.shape}'))
+            continue
+        cos, dif = cosine_rows(a, b).min(), np.abs(a - b).max()
+        worst_cos, worst_abs = min(worst_cos, cos), max(worst_abs, dif)
+        if cos < min_cosine or dif > max_abs:
+            failures.append((species, 't5_embedding', f'cos={cos:.6f} maxabs={dif:.4g}'))
+
+    print(f'\nchecked {len(built)} species')
+    print(f'  t5_embedding worst cosine  : {worst_cos:.8f}  (threshold {min_cosine})')
+    print(f'  t5_embedding worst max-abs : {worst_abs:.6g}  (threshold {max_abs})')
+    if failures:
+        print(f'\nFAIL — {len(failures)} mismatch(es):')
+        for species, field, detail in failures[:40]:
+            print(f'  {species:32s} {field:18s} {detail}')
+        if len(failures) > 40:
+            print(f'  ... and {len(failures) - 40} more')
+    else:
+        print('\nPASS — every field matches the reference')
+    return not failures
+
+
+def _brief(v):
+    if isinstance(v, np.ndarray):
+        return f'ndarray{v.shape}'
+    s = str(list(v)[:4])
+    return s + (' ...' if len(v) > 4 else '')
+
+
+# ------------------------------------------------------------------------------ main
+
+def pick_sample(names, n):
+    """Evenly spaced across the sorted list, so the tail gets covered too."""
+    names = sorted(names)
+    if n <= 0 or n >= len(names):
+        return set(names)
+    step = len(names) / n
+    return {names[int(i * step)] for i in range(n)}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--dataset_root', help='dataset root holding bvh/ and bvh_pose/')
+    ap.add_argument('--joint_name_map',
+                    help='per-species {orig: canonical} JSON. '
+                         'Defaults to <dataset_root>/joint_name_map.json when present.')
+    ap.add_argument('--t5_model', default='t5-base')
+    ap.add_argument('--max_path_len', type=int, default=5)
+    ap.add_argument('--device', default=None)
+    ap.add_argument('--output', help='where to write (default <dataset_root>/species_info_dict.npy)')
+    ap.add_argument('--verify_against', help='compare against this species_info_dict.npy; writes nothing')
+    ap.add_argument('--sample', type=int, default=0, help='verify only N species (0 = all)')
+    ap.add_argument('--export_map_from', help='dump orig->canonical map from this species_info_dict.npy and exit')
+    args = ap.parse_args()
+
+    if args.export_map_from:
+        src = np.load(args.export_map_from, allow_pickle=True).item()
+        name_map = {sp: dict(zip((str(n) for n in info['joints_name']),
+                                 (str(c) for c in info['rename_clean'])))
+                    for sp, info in src.items()}
+        out = args.output or 'joint_name_map.json'
+        with open(out, 'w', encoding='utf-8') as f:
+            json.dump(name_map, f, ensure_ascii=False, indent=1, sort_keys=True)
+        joints = sum(len(v) for v in name_map.values())
+        print(f'{len(name_map)} species / {joints} joints -> {out}')
+        return
+
+    if not args.dataset_root:
+        ap.error('--dataset_root is required unless --export_map_from is given')
+
+    map_path = args.joint_name_map
+    if map_path is None:
+        default_map = os.path.join(args.dataset_root, 'joint_name_map.json')
+        map_path = default_map if os.path.exists(default_map) else None
+
+    name_map = None
+    if map_path:
+        with open(map_path, encoding='utf-8') as f:
+            name_map = json.load(f)
+        print(f'joint name map: {map_path} ({len(name_map)} species)')
+    else:
+        print('[warn] no joint name map given — joint names will be cleaned automatically.\n'
+              '       That is correct for obj1k-style data, but it will NOT reproduce the\n'
+              '       curated canonical names used by the released zoo1030 species_info.')
+
+    only = None
+    reference = None
+    if args.verify_against:
+        reference = np.load(args.verify_against, allow_pickle=True).item()
+        if args.sample:
+            only = pick_sample(reference.keys(), args.sample)
+            print(f'verifying a sample of {len(only)} / {len(reference)} species')
+
+    built = build(args.dataset_root, name_map=name_map, t5_model=args.t5_model,
+                  max_path_len=args.max_path_len, device=args.device, only_species=only)
+
+    if reference is not None:
+        sys.exit(0 if verify(built, reference) else 1)
+
+    out = args.output or os.path.join(args.dataset_root, 'species_info_dict.npy')
+    np.save(out, dict(built))
+    print(f'{len(built)} species -> {out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/preprocess/extract_bvh_pose.py
+++ b/preprocess/extract_bvh_pose.py
@@ -46,7 +46,7 @@ def get_scale_cached(bvh_pth, auto_scale='base_mesh'):
         scale = 1 / diameter
     elif auto_scale == 'base_mesh':
         base_mesh_path = get_base_mesh_path_from_bvh(bvh_pth)
-        temp_vertices, temp_faces = read_obj_mesh(base_mesh_path)
+        temp_vertices, *_ = read_obj_mesh(base_mesh_path)
         v_max, v_min = temp_vertices.max(axis=0), temp_vertices.min(axis=0)
         scale_factor = (v_max - v_min).max()
         scale = 1 / scale_factor

--- a/preprocess/extract_character_from_fbx.py
+++ b/preprocess/extract_character_from_fbx.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import subprocess
 from glob import glob
 
 import bpy
@@ -8,7 +9,34 @@ import numpy as np
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from utils.bvh_tools import face_forward_bvh_with_scale
+
+def face_forward_bvh_external(bvh_path, scale=0.01, out_path=None):
+    """Run the torch-dependent BVH post-process in the configured Python env.
+
+    Blender bundles its own Python without torch, so importing utils.bvh_tools
+    here would fail. Shell out to $PYTHON (the env you run the rest of the
+    pipeline with) instead. Writes to `out_path`, defaulting to in-place.
+    """
+    python_bin = os.environ.get('PYTHON', sys.executable)
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    env = os.environ.copy()
+    env['PYTHONPATH'] = os.pathsep.join(
+        [repo_root, env.get('PYTHONPATH', '')]
+    ).rstrip(os.pathsep)
+    code = (
+        "import sys; "
+        "from utils import bvh as BVH; "
+        "from utils.bvh_tools import face_forward_bvh_with_scale; "
+        "src, dst, scale = sys.argv[1], sys.argv[2], float(sys.argv[3]); "
+        "anim, names, frametime = BVH.load(src); "
+        "face_forward_bvh_with_scale(dst, anim, names, frametime, scale)"
+    )
+    subprocess.run(
+        [python_bin, '-c', code, bvh_path, out_path or bvh_path, str(scale)],
+        check=True,
+        cwd=repo_root,
+        env=env,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -249,10 +277,8 @@ def find_base_fbx(fbx_files, character_name):
 # Main
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    import utils.bvh as BVH  # kept for the optional face-forward step below
-
-    data_root = 'Truebone_Z-OO'
-    target_folder = 'zoo'
+    data_root = os.environ.get('DATA_ROOT', 'Truebone_Z-OO')
+    target_folder = os.environ.get('ZOO_ROOT', 'zoo')
     os.makedirs(target_folder, exist_ok=True)
 
     character_folder = os.path.join(target_folder, 'characters_fix_facezplus')
@@ -262,8 +288,11 @@ if __name__ == "__main__":
 
     skip_tpose = True
 
+    # Leading-underscore folders are bookkeeping, not characters: fix_fbx_batch.py
+    # drops _fix_meta_* / _fix_logs_* next to the fixed FBX it writes.
     character_dirs = sorted(
-        d for d in glob(os.path.join(data_root, "*")) if os.path.isdir(d)
+        d for d in glob(os.path.join(data_root, "*"))
+        if os.path.isdir(d) and not os.path.basename(d).startswith("_")
     )
 
     for char_dir in character_dirs:
@@ -297,6 +326,17 @@ if __name__ == "__main__":
         )
         bvh_joint_names = _read_bvh_joint_names(rest_bvh_path) if rest_bvh_path else None
 
+        # 1b) Face-forwarded + scaled copy of the rest pose. Inference reads this as
+        #     the rest-pose template (utils/npy2bvh.py looks for `*_ffs.bvh`); without
+        #     it BVH export fails, and substituting the unscaled rest.bvh silently
+        #     produces a collapsed mesh because the offsets are 100x too large.
+        if rest_bvh_path:
+            ffs_path = os.path.join(char_save_dir, f'{character_name}_ffs.bvh')
+            try:
+                face_forward_bvh_external(rest_bvh_path, scale=0.01, out_path=ffs_path)
+            except Exception as e:
+                print(f"⚠️ Could not write {os.path.basename(ffs_path)}: {e}")
+
         # 2) Mesh/weights/textures from the base FBX, weights aligned to BVH joints
         extract_character_data(base_fbx, char_save_dir, bvh_joint_names=bvh_joint_names)
 
@@ -313,10 +353,8 @@ if __name__ == "__main__":
                 if bvh_pth is None:
                     continue
 
-                # --- Optional: face-forward + scale pass on the freshly exported BVH ---
-                anim, name, ft = BVH.load(bvh_pth)
-                print(anim.rotations.shape)
-                face_forward_bvh_with_scale(bvh_pth, anim, name, ft, scale=0.01)
+                # --- Face-forward + scale pass on the freshly exported BVH ---
+                face_forward_bvh_external(bvh_pth, scale=0.01)
             except Exception as e:
                 print(e)
         print(f"✅ Done with {character_name}")

--- a/preprocess/fix_fbx.py
+++ b/preprocess/fix_fbx.py
@@ -1,0 +1,600 @@
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+
+import bpy
+from mathutils import Vector
+
+
+class SimpleLogger:
+    def __init__(self, filepath, mode="a"):
+        self.filepath = filepath
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        self.file = open(filepath, mode, buffering=1)
+
+    def log(self, message: str):
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.file.write(f"[{timestamp}] {message}\n")
+
+    def error(self, message: str):
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.file.write(f"[{timestamp}] ERROR: {message}\n")
+
+    def close(self):
+        self.file.close()
+
+
+def parse_args():
+    argv = sys.argv
+    argv = argv[argv.index("--") + 1:] if "--" in argv else []
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--in", dest="inpath", required=True, help="input FBX path")
+    parser.add_argument("--out", dest="outpath", required=True, help="output FBX path")
+    parser.add_argument("--prefer", type=str, default="", help="comma-separated translation bones")
+    parser.add_argument("--fixed-len", type=float, default=0.01, help="length for shortened leaf parents")
+    parser.add_argument("--flagpole-threshold", type=float, default=10.0, help="max allowed scaled bone length")
+    parser.add_argument("--log", type=str, default="", help="optional log file")
+    parser.add_argument("--meta", type=str, default="", help="optional metadata JSON path")
+    parser.add_argument("--expect-clean-signature", type=str, default="",
+                        help="expected 'shortened,deleted' cleanup totals")
+    parser.add_argument("--analysis-only", action="store_true", help="analyze but do not export")
+    parser.add_argument("--skip-clean", action="store_true", help="skip no-weight leaf cleanup")
+    parser.add_argument("--skip-root-push", action="store_true", help="skip root-motion push")
+    return parser.parse_args(argv)
+
+
+def safe_log_path(inpath):
+    stem = re.sub(r"[^A-Za-z0-9_.-]+", "_", os.path.splitext(os.path.basename(inpath))[0])
+    return os.path.join("logs", "fix_fbx", f"{stem}.log")
+
+
+def cleanup_scene():
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete()
+    for collection in (bpy.data.meshes, bpy.data.materials, bpy.data.images,
+                       bpy.data.armatures, bpy.data.actions):
+        for block in list(collection):
+            if block.users == 0:
+                collection.remove(block)
+
+
+def ensure_blender_fbx_import_compat():
+    """Patch Blender 5.x FBX importer expectations for older FBX light fields."""
+    import io_scene_fbx.import_fbx as import_fbx
+
+    if getattr(import_fbx.blen_read_light, "_mocapanything_cast_shadow_patch", False):
+        return
+
+    globals_ = import_fbx.blen_read_light.__globals__
+
+    def blen_read_light_compat(fbx_tmpl, fbx_obj, settings):
+        import math
+
+        elem_name_utf8 = globals_["elem_name_ensure_class"](fbx_obj, b"NodeAttribute")
+        fbx_props = (
+            globals_["elem_find_first"](fbx_obj, b"Properties70"),
+            globals_["elem_find_first"](fbx_tmpl, b"Properties70", globals_["fbx_elem_nil"]),
+        )
+        light_type = {
+            0: "POINT",
+            1: "SUN",
+            2: "SPOT",
+        }.get(globals_["elem_props_get_enum"](fbx_props, b"LightType", 0), "POINT")
+
+        lamp = bpy.data.lights.new(name=elem_name_utf8, type=light_type)
+
+        if light_type == "SPOT":
+            spot_size = globals_["elem_props_get_number"](fbx_props, b"OuterAngle", None)
+            if spot_size is None:
+                spot_size = globals_["elem_props_get_number"](fbx_props, b"Cone angle", 45.0)
+            lamp.spot_size = math.radians(spot_size)
+
+            spot_blend = globals_["elem_props_get_number"](fbx_props, b"InnerAngle", None)
+            if spot_blend is None:
+                spot_blend = globals_["elem_props_get_number"](fbx_props, b"HotSpot", 45.0)
+            lamp.spot_blend = 1.0 - (spot_blend / spot_size)
+
+        lamp.color = globals_["elem_props_get_color_rgb"](fbx_props, b"Color", (1.0, 1.0, 1.0))
+        lamp.energy = globals_["elem_props_get_number"](fbx_props, b"Intensity", 100.0) / 100.0
+        lamp.exposure = globals_["elem_props_get_number"](fbx_props, b"Exposure", 0.0)
+        lamp.use_shadow = globals_["elem_props_get_bool"](fbx_props, b"CastShadow", True)
+        if hasattr(lamp, "cycles") and hasattr(lamp.cycles, "cast_shadow"):
+            lamp.cycles.cast_shadow = lamp.use_shadow
+
+        if settings.use_custom_props:
+            globals_["blen_read_custom_properties"](fbx_obj, lamp, settings)
+
+        return lamp
+
+    blen_read_light_compat._mocapanything_cast_shadow_patch = True
+    import_fbx.blen_read_light = blen_read_light_compat
+
+
+def get_skinned_meshes(arm_obj):
+    meshes = []
+    for obj in bpy.data.objects:
+        if obj.type != "MESH":
+            continue
+        for modifier in obj.modifiers:
+            if modifier.type == "ARMATURE" and modifier.object == arm_obj:
+                meshes.append(obj)
+                break
+    return meshes
+
+
+def count_skinned_meshes(arm_obj):
+    return len(get_skinned_meshes(arm_obj))
+
+
+def import_main_armature(inpath):
+    ensure_blender_fbx_import_compat()
+    before = set(bpy.data.objects)
+    bpy.ops.import_scene.fbx(filepath=inpath, automatic_bone_orientation=False)
+    after = [obj for obj in bpy.data.objects if obj not in before]
+    candidates = [obj for obj in after if obj.type == "ARMATURE"] or [
+        obj for obj in bpy.data.objects if obj.type == "ARMATURE"
+    ]
+    if not candidates:
+        raise RuntimeError("No armature found")
+    arm = max(candidates, key=count_skinned_meshes)
+    bpy.context.view_layer.objects.active = arm
+    return arm
+
+
+def has_weight(meshes, bone_name, min_weight=1e-6):
+    for mesh in meshes:
+        group = mesh.vertex_groups.get(bone_name)
+        if not group:
+            continue
+        group_idx = group.index
+        for vertex in mesh.data.vertices:
+            for weight in vertex.groups:
+                if weight.group == group_idx and weight.weight > min_weight:
+                    return True
+    return False
+
+
+def clean_and_shorten_by_weights(arm, logger, fixed_len=0.01):
+    """Shorten parents of no-weight leaf bones, then delete those no-weight leaves."""
+    meshes = get_skinned_meshes(arm)
+
+    bpy.ops.object.mode_set(mode="OBJECT")
+    bpy.ops.object.select_all(action="DESELECT")
+    arm.select_set(True)
+    bpy.context.view_layer.objects.active = arm
+    bpy.ops.object.mode_set(mode="EDIT")
+
+    leaf_names = []
+    parent_to_leaf = {}
+    for bone in arm.data.edit_bones:
+        if len(bone.children) == 0:
+            leaf_names.append(bone.name)
+            if bone.parent and len(bone.parent.children) == 1:
+                parent_to_leaf[bone.parent.name] = bone.name
+
+    bpy.ops.object.mode_set(mode="OBJECT")
+    leaf_no_weight = {name for name in leaf_names if not has_weight(meshes, name)}
+    parents_to_shorten = [
+        parent for parent, leaf in parent_to_leaf.items() if leaf in leaf_no_weight
+    ]
+
+    bpy.ops.object.mode_set(mode="EDIT")
+    shortened = 0
+    for parent_name in parents_to_shorten:
+        parent = arm.data.edit_bones.get(parent_name)
+        if not parent:
+            continue
+        if len(parent.children) == 1 and len(parent.children[0].children) == 0:
+            direction = parent.y_axis.normalized() if parent.y_axis.length > 0 else Vector((0, 1, 0))
+            parent.tail = parent.head + direction * float(fixed_len)
+            shortened += 1
+
+    bpy.ops.object.mode_set(mode="OBJECT")
+    for mesh in meshes:
+        for bone_name in leaf_no_weight:
+            group = mesh.vertex_groups.get(bone_name)
+            if group:
+                mesh.vertex_groups.remove(group)
+
+    bpy.ops.object.mode_set(mode="EDIT")
+    deleted = 0
+    for bone_name in list(leaf_no_weight):
+        bone = arm.data.edit_bones.get(bone_name)
+        if bone:
+            arm.data.edit_bones.remove(bone)
+            deleted += 1
+
+    bpy.ops.object.mode_set(mode="OBJECT")
+    logger.log(f"Shortened {shortened} leaf parents; deleted {deleted} no-weight leaves")
+    return shortened, deleted
+
+
+def clean_leaf_bones_until_stable(arm, logger, fixed_len=0.01):
+    total_shortened = 0
+    total_deleted = 0
+    while True:
+        shortened, deleted = clean_and_shorten_by_weights(arm, logger, fixed_len=fixed_len)
+        total_shortened += shortened
+        total_deleted += deleted
+        if deleted == 0:
+            break
+    logger.log(f"Cleanup totals: shortened={total_shortened}, deleted={total_deleted}")
+    return total_shortened, total_deleted
+
+
+def has_flagpole_bone(arm, len_threshold=10.0, topk_log=3, logger=None):
+    scale = max(abs(arm.scale.x), abs(arm.scale.y), abs(arm.scale.z))
+    bpy.ops.object.mode_set(mode="OBJECT")
+    bpy.ops.object.select_all(action="DESELECT")
+    arm.select_set(True)
+    bpy.context.view_layer.objects.active = arm
+    bpy.ops.object.mode_set(mode="EDIT")
+
+    lengths = []
+    names = []
+    for bone in arm.data.edit_bones:
+        lengths.append((bone.tail - bone.head).length * scale)
+        names.append(bone.name)
+
+    bpy.ops.object.mode_set(mode="OBJECT")
+    if not lengths:
+        return False, ("", 0.0)
+
+    max_idx = max(range(len(lengths)), key=lambda i: lengths[i])
+    if logger and topk_log:
+        for idx in sorted(range(len(lengths)), key=lambda i: lengths[i], reverse=True)[:topk_log]:
+            logger.log(f"[DBG] bone_len rank {idx}: {names[idx]} len={lengths[idx]:.3f}")
+    return lengths[max_idx] > len_threshold, (names[max_idx], lengths[max_idx])
+
+
+def has_keyframe(action, bone_name, data_path, frame):
+    target_path = f'pose.bones["{bone_name}"].{data_path}'
+    for curve in action.fcurves:
+        if curve.data_path != target_path:
+            continue
+        for keyframe in curve.keyframe_points:
+            if int(round(keyframe.co.x)) == frame:
+                return True
+    return False
+
+
+def measure_bone_loc_motion(arm, logger, start=None, end=None):
+    action = arm.animation_data.action if (arm.animation_data and arm.animation_data.action) else None
+    if not action:
+        raise RuntimeError("Armature has no available action")
+    frame_start, frame_end = map(int, action.frame_range)
+    start = frame_start if start is None else start
+    end = frame_end if end is None else end
+    bpy.context.scene.frame_start, bpy.context.scene.frame_end = start, end
+    result = {}
+    bpy.context.scene.frame_set(start)
+    base = {pb.name: pb.location.copy() for pb in arm.pose.bones}
+    for frame in range(start, end + 1):
+        bpy.context.scene.frame_set(frame)
+        for pose_bone in arm.pose.bones:
+            delta = (pose_bone.location - base[pose_bone.name]).length
+            result[pose_bone.name] = max(result.get(pose_bone.name, 0.0), delta)
+    logger.log(f"Measured location motion on frames {start}-{end}")
+    return start, end, result
+
+
+def bones_with_skin_weights(arm, min_weight=1e-6):
+    weighted = set()
+    meshes = get_skinned_meshes(arm)
+    deform_bone_names = {bone.name for bone in arm.data.bones if bone.use_deform}
+    for mesh in meshes:
+        idx_to_name = {group.index: group.name for group in mesh.vertex_groups}
+        for vertex in mesh.data.vertices:
+            for group in vertex.groups:
+                if group.weight > min_weight:
+                    name = idx_to_name.get(group.group)
+                    if name in deform_bone_names:
+                        weighted.add(name)
+        if len(weighted) == len(deform_bone_names):
+            break
+    return weighted
+
+
+def bone_depth(arm, bone_name):
+    bone = arm.data.bones.get(bone_name)
+    if bone is None:
+        return 10**9
+    depth = 0
+    while bone.parent is not None:
+        depth += 1
+        bone = bone.parent
+    return depth
+
+
+def build_parent_children_maps(arm):
+    parent = {}
+    children = {}
+    for bone in arm.data.bones:
+        parent[bone.name] = bone.parent.name if bone.parent else None
+        children.setdefault(bone.name, [])
+    for bone in arm.data.bones:
+        if bone.parent:
+            children[bone.parent.name].append(bone.name)
+    return parent, children
+
+
+def path_root_to(parent_map, bone_name):
+    chain = []
+    current = bone_name
+    while current is not None:
+        chain.append(current)
+        current = parent_map.get(current)
+    chain.reverse()
+    return chain
+
+
+def subtree_has_weighted(start_name, children, weighted_set):
+    stack = [start_name]
+    while stack:
+        node = stack.pop()
+        if node in weighted_set:
+            return True
+        stack.extend(children.get(node, []))
+    return False
+
+
+def is_trunk_bone_allow_weight(bone_name, parent_map, children, weighted_set):
+    path = path_root_to(parent_map, bone_name)
+    path_set = set(path)
+    for idx in range(len(path) - 1):
+        ancestor = path[idx]
+        next_on_path = path[idx + 1]
+        for child in children.get(ancestor, []):
+            if child == next_on_path or child in path_set:
+                continue
+            if subtree_has_weighted(child, children, weighted_set):
+                return False
+    return True
+
+
+def pick_translation_bones(metrics, arm, logger, rel_ratio=0.02, abs_eps=0.05,
+                           depth_limit=2, exclude_weighted=True, min_weight=1e-6):
+    if not metrics:
+        return None, set()
+    max_all = max(max(metrics.values()), 1e-8)
+    base_keep = {
+        name for name, value in metrics.items()
+        if value >= max_all * rel_ratio and value >= abs_eps
+    } or set(metrics.keys())
+
+    eligible = {name for name in base_keep if bone_depth(arm, name) <= depth_limit}
+    if not eligible:
+        logger.log("No eligible translation bones after depth filter")
+        return "NA", set()
+
+    if exclude_weighted:
+        weighted = bones_with_skin_weights(arm, min_weight=min_weight)
+        parent_map, children = build_parent_children_maps(arm)
+        eligible = {
+            name for name in eligible
+            if name not in weighted or is_trunk_bone_allow_weight(name, parent_map, children, weighted)
+        }
+        logger.log(f"Eligible translation bones after skin/trunk filter: {sorted(eligible)}")
+
+    if not eligible:
+        logger.log("No eligible translation bones after skin weights filter")
+        return "NA", set()
+
+    main = max(eligible, key=lambda name: metrics.get(name, 0.0))
+    keep = {name for name in eligible if name in base_keep}
+    keep.add(main)
+    return main, keep
+
+
+def ensure_single_root(arm, root_name="Root", align_to_bone=None):
+    bpy.context.view_layer.objects.active = arm
+    bpy.ops.object.mode_set(mode="EDIT")
+    edit_bones = arm.data.edit_bones
+    roots = [bone for bone in edit_bones if bone.parent is None]
+    if len(roots) <= 1:
+        out = roots[0].name if roots else None
+        bpy.ops.object.mode_set(mode="POSE")
+        return out
+
+    root = edit_bones.new(root_name)
+    if align_to_bone is not None and align_to_bone in edit_bones:
+        bone = edit_bones[align_to_bone]
+        root.head = bone.head.copy()
+        root.tail = (bone.head + Vector((0, 1, 0))).copy()
+    else:
+        root.head = Vector((0, 0, 0))
+        root.tail = Vector((0, 1, 0))
+
+    for bone in roots:
+        if bone != root:
+            bone.parent = root
+    bpy.ops.object.mode_set(mode="POSE")
+    arm.data.bones[root_name].use_deform = False
+    return root_name
+
+
+def head_in_armature_space(pose_bone):
+    return (pose_bone.matrix @ Vector((0, 0, 0, 1))).to_3d()
+
+
+def select_translation_bones(arm, logger, prefer_bones=None):
+    frame_start, frame_end, metrics = measure_bone_loc_motion(arm, logger)
+    main_bone, keep_set = pick_translation_bones(metrics, arm, logger)
+    if prefer_bones:
+        main_bone = prefer_bones
+    if isinstance(main_bone, str):
+        main_bone = [main_bone]
+    return frame_start, frame_end, main_bone, keep_set
+
+
+def push_translation_to_root(arm, logger, prefer_bones=None):
+    frame_start, frame_end, main_bone, keep_set = select_translation_bones(
+        arm, logger, prefer_bones=prefer_bones
+    )
+    if not main_bone or "NA" in main_bone:
+        logger.log("No translation bone selected; skip root push")
+        return main_bone
+
+    logger.log(f"locator = {main_bone}, frames: {frame_start}-{frame_end}")
+    root_name = ensure_single_root(arm, "Root", align_to_bone=main_bone[0])
+    if root_name is None:
+        pose_bone = arm.pose.bones[main_bone[0]]
+        while pose_bone.parent:
+            pose_bone = pose_bone.parent
+        root_name = pose_bone.name
+
+    if prefer_bones:
+        push_flag = not (root_name == main_bone[0] and len(main_bone) == 1)
+    else:
+        push_flag = root_name not in keep_set
+    if not push_flag:
+        logger.log(f"Root {root_name} already has translation or selected locator; skip root push")
+        return main_bone
+
+    logger.log(f"Current root is {root_name}; pushing {main_bone} translation to root")
+    bpy.context.view_layer.objects.active = arm
+    bpy.ops.object.mode_set(mode="EDIT")
+    root_edit_bone = arm.data.edit_bones[root_name]
+    root_edit_bone.tail = (root_edit_bone.head + Vector((0.0, 1.0, 0.0))).copy()
+    main_edit_bone = arm.data.edit_bones[main_bone[0]]
+    delta_static = (root_edit_bone.head - main_edit_bone.head).copy()
+    bpy.ops.object.mode_set(mode="POSE")
+
+    original_matrix_world = arm.matrix_world.copy()
+    arm.location = (0, 0, 0)
+    arm.rotation_euler = (0, 0, 0)
+    arm.scale = (1, 1, 1)
+
+    root_pose_bone = arm.pose.bones[root_name]
+    locator = arm.pose.bones[main_bone[0]]
+    loc_record = []
+    for frame in range(frame_start, frame_end + 1):
+        bpy.context.scene.frame_set(frame)
+        loc_record.append(head_in_armature_space(locator) - head_in_armature_space(root_pose_bone))
+
+    if len(main_bone) > 1:
+        for loc_name in main_bone[1:]:
+            sub_locator = arm.pose.bones[loc_name]
+            bpy.ops.object.mode_set(mode="EDIT")
+            loc_edit_bone = arm.data.edit_bones[loc_name]
+            loc_edit_head = loc_edit_bone.head.copy()
+            bpy.ops.object.mode_set(mode="POSE")
+            for frame in range(frame_start, frame_end + 1):
+                bpy.context.scene.frame_set(frame)
+                if sub_locator.location == Vector((0, 0, 0)) and not has_keyframe(
+                    arm.animation_data.action, loc_name, "location", frame
+                ):
+                    bpy.context.scene.frame_set(frame - 1)
+                    prev_location = sub_locator.location.copy()
+                    bpy.context.scene.frame_set(frame)
+                    sub_locator.location = prev_location
+                    sub_locator.keyframe_insert(data_path="location", frame=frame)
+                loc_record[frame - frame_start] += head_in_armature_space(sub_locator) - loc_edit_head
+
+            for frame in range(frame_start, frame_end + 1):
+                bpy.context.scene.frame_set(frame)
+                sub_locator.location = Vector((0, 0, 0))
+                sub_locator.keyframe_insert(data_path="location", frame=frame)
+
+    for frame in range(frame_start, frame_end + 1):
+        bpy.context.scene.frame_set(frame)
+        root_pose_bone.location = loc_record[frame - frame_start] + delta_static
+        root_pose_bone.keyframe_insert(data_path="location", frame=frame)
+        locator.location = Vector((0, 0, 0))
+        locator.keyframe_insert(data_path="location", frame=frame)
+    arm.matrix_world = original_matrix_world
+    return main_bone
+
+
+def export_fbx_selection(filepath, objects, logger, bake_anim=True):
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    for obj in bpy.context.selected_objects:
+        obj.select_set(False)
+    for obj in objects:
+        obj.select_set(True)
+    bpy.context.view_layer.objects.active = objects[0]
+    bpy.ops.export_scene.fbx(
+        filepath=filepath,
+        use_selection=True,
+        add_leaf_bones=False,
+        bake_space_transform=True,
+        apply_unit_scale=True,
+        path_mode="COPY",
+        embed_textures=True,
+        bake_anim=bake_anim,
+        bake_anim_use_all_bones=True,
+        bake_anim_force_startend_keying=True,
+        armature_nodetype="NULL",
+        axis_forward="-Z",
+        axis_up="Y",
+    )
+    logger.log(f"[OK] FBX exported -> {filepath}")
+
+
+def main():
+    args = parse_args()
+    prefer_bones = [item for item in args.prefer.split(",") if item]
+    logger = SimpleLogger(args.log or safe_log_path(args.inpath), mode="w")
+    logger.log(f"Fixing {args.inpath} -> {args.outpath}")
+    meta = {
+        "input": args.inpath,
+        "output": args.outpath,
+        "success": False,
+        "analysis_only": bool(args.analysis_only),
+        "prefer": prefer_bones,
+        "locator": [],
+        "cleanup": {"shortened": 0, "deleted": 0},
+        "error": "",
+    }
+
+    try:
+        cleanup_scene()
+        arm = import_main_armature(args.inpath)
+        if not args.skip_clean:
+            shortened, deleted = clean_leaf_bones_until_stable(arm, logger, fixed_len=args.fixed_len)
+            meta["cleanup"] = {"shortened": shortened, "deleted": deleted}
+        if args.expect_clean_signature:
+            expected_shortened, expected_deleted = [
+                int(x.strip()) for x in args.expect_clean_signature.split(",", 1)
+            ]
+            actual = meta["cleanup"]
+            if (actual["shortened"], actual["deleted"]) != (expected_shortened, expected_deleted):
+                raise RuntimeError(
+                    "Cleanup signature mismatch: "
+                    f"actual={actual['shortened']},{actual['deleted']} "
+                    f"expected={expected_shortened},{expected_deleted}"
+                )
+        bad, info = has_flagpole_bone(
+            arm,
+            len_threshold=args.flagpole_threshold,
+            logger=logger,
+        )
+        if bad:
+            bone_name, bone_len = info
+            raise RuntimeError(f"Flagpole bone detected: {bone_name}, len={bone_len:.3f}")
+        if args.skip_root_push:
+            _, _, locator, _ = select_translation_bones(arm, logger, prefer_bones=prefer_bones)
+        else:
+            locator = push_translation_to_root(arm, logger, prefer_bones=prefer_bones)
+        meta["locator"] = [x for x in (locator or []) if x and x != "NA"]
+        if not args.analysis_only:
+            meshes = get_skinned_meshes(arm)
+            export_fbx_selection(args.outpath, [arm] + meshes, logger)
+        meta["success"] = True
+    except Exception as exc:
+        meta["error"] = str(exc)
+        logger.error(str(exc))
+        raise
+    finally:
+        if args.meta:
+            os.makedirs(os.path.dirname(args.meta), exist_ok=True)
+            with open(args.meta, "w") as f:
+                json.dump(meta, f, indent=2, ensure_ascii=False)
+        logger.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess/fix_fbx_batch.py
+++ b/preprocess/fix_fbx_batch.py
@@ -1,0 +1,261 @@
+import argparse
+import json
+import os
+import shutil
+import subprocess
+from collections import Counter, defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+from tqdm import tqdm
+
+
+def collect_fbx_files(input_root):
+    jobs = []
+    for char_name in sorted(os.listdir(input_root)):
+        char_dir = os.path.join(input_root, char_name)
+        if not os.path.isdir(char_dir):
+            continue
+        for name in sorted(os.listdir(char_dir)):
+            if name.lower().endswith(".fbx"):
+                jobs.append((char_name, os.path.join(char_dir, name)))
+    return jobs
+
+
+def mode_or_empty(values):
+    if not values:
+        return ()
+    return Counter(values).most_common(1)[0][0]
+
+
+def write_tsv(path, rows):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        for row in rows:
+            f.write("\t".join(str(x) for x in row) + "\n")
+
+
+def run_one(args_tuple):
+    (
+        char_name,
+        inpath,
+        input_root,
+        output_root,
+        blender,
+        script,
+        skip_existing,
+        analysis_only,
+        prefer,
+        expected_clean_signature,
+        pass_name,
+    ) = args_tuple
+    rel = os.path.relpath(inpath, input_root)
+    outpath = os.path.join(output_root, rel)
+    meta_dir = os.path.join(output_root, f"_fix_meta_{pass_name}", char_name)
+    log_dir = os.path.join(output_root, f"_fix_logs_{pass_name}", char_name)
+    stem = os.path.splitext(os.path.basename(inpath))[0]
+    meta_path = os.path.join(meta_dir, stem + ".json")
+    log_path = os.path.join(log_dir, stem + ".log")
+
+    if (
+        skip_existing
+        and not analysis_only
+        and os.path.exists(outpath)
+        and os.path.exists(meta_path)
+    ):
+        try:
+            with open(meta_path, "r") as f:
+                meta = json.load(f)
+            if meta.get("success"):
+                meta["status"] = "skipped"
+                meta["species"] = char_name
+                meta["relpath"] = rel
+                return meta
+        except Exception:
+            pass
+
+    os.makedirs(os.path.dirname(outpath), exist_ok=True)
+    os.makedirs(meta_dir, exist_ok=True)
+    os.makedirs(log_dir, exist_ok=True)
+
+    cmd = [
+        blender,
+        "--background",
+        "--python",
+        script,
+        "--",
+        "--in",
+        inpath,
+        "--out",
+        outpath,
+        "--log",
+        log_path,
+        "--meta",
+        meta_path,
+    ]
+    if analysis_only:
+        cmd.append("--analysis-only")
+    if prefer:
+        cmd.extend(["--prefer", ",".join(prefer)])
+    if expected_clean_signature:
+        cmd.extend(["--expect-clean-signature", expected_clean_signature])
+
+    try:
+        subprocess.run(cmd, check=True)
+        with open(meta_path, "r") as f:
+            meta = json.load(f)
+        meta["species"] = char_name
+        meta["relpath"] = rel
+        if not analysis_only and not os.path.exists(outpath):
+            raise FileNotFoundError(f"Fixer did not create output: {outpath}")
+        meta["status"] = "done"
+        return meta
+    except Exception as exc:
+        meta = {
+            "input": inpath,
+            "output": outpath,
+            "success": False,
+            "analysis_only": analysis_only,
+            "locator": [],
+            "cleanup": {"shortened": 0, "deleted": 0},
+            "error": str(exc),
+            "status": "failed",
+            "species": char_name,
+            "relpath": rel,
+        }
+        if os.path.exists(meta_path):
+            try:
+                with open(meta_path, "r") as f:
+                    meta.update(json.load(f))
+                meta["status"] = "failed"
+                meta["species"] = char_name
+                meta["relpath"] = rel
+            except Exception:
+                pass
+        if os.path.exists(outpath):
+            os.remove(outpath)
+        return meta
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input_root", required=True)
+    parser.add_argument("--output_root", required=True)
+    parser.add_argument("--blender", required=True)
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--skip_existing", action="store_true")
+    parser.add_argument("--single_pass", action="store_true",
+                        help="run a single export pass without species-level preference voting")
+    args = parser.parse_args()
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    script = os.path.join(repo_root, "preprocess", "fix_fbx.py")
+    jobs = collect_fbx_files(args.input_root)
+    print(f"==> Fixing {len(jobs)} FBX files with {args.workers} workers")
+
+    def run_tasks(task_args, desc):
+        results = []
+        if args.workers <= 1:
+            for task in tqdm(task_args, desc=desc):
+                results.append(run_one(task))
+        else:
+            with ProcessPoolExecutor(max_workers=args.workers) as executor:
+                futures = [executor.submit(run_one, task) for task in task_args]
+                for fut in tqdm(as_completed(futures), total=len(futures), desc=desc):
+                    results.append(fut.result())
+        done = sum(1 for item in results if item.get("success"))
+        failed = len(results) - done
+        print(f"==> {desc}: success={done}, failed={failed}")
+        return results
+
+    if args.single_pass:
+        pass2_tasks = [
+            (
+                char_name, inpath, args.input_root, args.output_root, args.blender,
+                script, args.skip_existing, False, [], "", "pass2",
+            )
+            for char_name, inpath in jobs
+        ]
+        pass2_results = run_tasks(pass2_tasks, "fix_fbx_export")
+        failed_rows = [
+            (os.path.relpath(item["input"], args.input_root), item.get("error", ""))
+            for item in pass2_results if not item.get("success")
+        ]
+        write_tsv(os.path.join(args.output_root, "_fix_failed.tsv"), failed_rows)
+        return
+
+    pass1_tasks = [
+        (
+            char_name, inpath, args.input_root, args.output_root, args.blender,
+            script, False, True, [], "", "pass1",
+        )
+        for char_name, inpath in jobs
+    ]
+    pass1_results = run_tasks(pass1_tasks, "fix_fbx_analyze")
+
+    by_species = defaultdict(list)
+    for result in pass1_results:
+        if result.get("success"):
+            char_name = result.get("species", "")
+            locator = tuple(result.get("locator") or [])
+            cleanup = result.get("cleanup") or {}
+            signature = (int(cleanup.get("shortened", 0)), int(cleanup.get("deleted", 0)))
+            by_species[char_name].append((locator, signature))
+
+    species_pref = {}
+    preference_rows = [("species", "prefer", "cleanup_signature", "valid_count", "invalid_count")]
+    for char_name in sorted({name for name, _ in jobs}):
+        records = by_species.get(char_name, [])
+        locator_mode = mode_or_empty([record[0] for record in records])
+        cleanup_mode = mode_or_empty([record[1] for record in records])
+        species_pref[char_name] = (locator_mode, cleanup_mode)
+        invalid_count = sum(1 for name, _ in jobs if name == char_name) - len(records)
+        preference_rows.append(
+            (
+                char_name,
+                ",".join(locator_mode),
+                ",".join(str(x) for x in cleanup_mode),
+                len(records),
+                invalid_count,
+            )
+        )
+    write_tsv(os.path.join(args.output_root, "_fix_preferences.txt"), preference_rows)
+
+    pass2_tasks = []
+    for char_name, inpath in jobs:
+        locator_mode, cleanup_mode = species_pref.get(char_name, ((), ()))
+        if not cleanup_mode:
+            continue
+        pass2_tasks.append(
+            (
+                char_name,
+                inpath,
+                args.input_root,
+                args.output_root,
+                args.blender,
+                script,
+                args.skip_existing,
+                False,
+                list(locator_mode),
+                f"{cleanup_mode[0]},{cleanup_mode[1]}",
+                "pass2",
+            )
+        )
+    pass2_results = run_tasks(pass2_tasks, "fix_fbx_export")
+
+    failed_rows = [("input", "error")]
+    for result in pass1_results + pass2_results:
+        if not result.get("success"):
+            failed_rows.append(
+                (
+                    os.path.relpath(result.get("input", ""), args.input_root),
+                    result.get("error", ""),
+                )
+            )
+            outpath = result.get("output", "")
+            if outpath and os.path.exists(outpath):
+                os.remove(outpath)
+    write_tsv(os.path.join(args.output_root, "_fix_failed.tsv"), failed_rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess/preprocess_image_only.py
+++ b/preprocess/preprocess_image_only.py
@@ -21,9 +21,30 @@ from tqdm import tqdm
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from models.v1.video2mesh.pipeline_triposg import TripoSGPipeline
+try:
+    from models.v1.video2mesh.pipeline_triposg import TripoSGPipeline
+except Exception:  # TripoSG not installed / not on PYTHONPATH
+    TripoSGPipeline = None
+
 from preprocess.briarmbg import BriaRMBG
 from preprocess.image_process import prepare_image
+
+
+class Dinov2Only:
+    """The DINOv2 half of TripoSGPipeline, loaded straight from `facebook/dinov2-large`.
+
+    This stage only ever touches `feature_extractor_dinov2` / `image_encoder_dinov2`,
+    which are exactly that model — so pulling in TripoSG and its geometry weights just
+    to reach them makes the mesh-free path depend on something it never uses.
+    """
+
+    def __init__(self, device, dtype, model_id="facebook/dinov2-large"):
+        from transformers import AutoImageProcessor, Dinov2Model
+
+        self.feature_extractor_dinov2 = AutoImageProcessor.from_pretrained(model_id)
+        self.image_encoder_dinov2 = (
+            Dinov2Model.from_pretrained(model_id).to(device, dtype).eval()
+        )
 
 
 def process_sample(img_files, pipe, rmbg_net, device, dtype, out_file):
@@ -77,6 +98,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_root", type=str, default="zoo",
                         help="dataset root containing image/")
     parser.add_argument("--triposg_weights_dir", type=str, default="checkpoints/TripoSG")
+    parser.add_argument("--dinov2_model", type=str, default="facebook/dinov2-large",
+                        help="fallback image encoder, used when TripoSG is unavailable")
     parser.add_argument("--rmbg_weights_dir", type=str, default="checkpoints/RMBG-1.4")
     args = parser.parse_args()
 
@@ -94,11 +117,18 @@ if __name__ == "__main__":
     device = "cuda"
     dtype = torch.float16
 
-    rmbg_net = BriaRMBG.from_pretrained(args.rmbg_weights_dir).to(device)
+    # The weights repo does not ship RMBG; fall back to the HuggingFace id it lives at.
+    rmbg_src = args.rmbg_weights_dir if os.path.isdir(args.rmbg_weights_dir) else "briaai/RMBG-1.4"
+    print(f"Loading background remover from {rmbg_src}")
+    rmbg_net = BriaRMBG.from_pretrained(rmbg_src).to(device)
     rmbg_net.eval()
 
-    print("Loading TripoSG pipeline (DINOv2 image encoder only)...")
-    pipe = TripoSGPipeline.from_pretrained(args.triposg_weights_dir).to(device, dtype)
+    if TripoSGPipeline is not None and os.path.isdir(args.triposg_weights_dir):
+        print("Loading TripoSG pipeline (DINOv2 image encoder only)...")
+        pipe = TripoSGPipeline.from_pretrained(args.triposg_weights_dir).to(device, dtype)
+    else:
+        print(f"Loading {args.dinov2_model} directly (TripoSG not available).")
+        pipe = Dinov2Only(device, dtype, model_id=args.dinov2_model)
 
     view_pairs = find_view_dirs(image_folder)
     view_pairs = [p for i, p in enumerate(view_pairs) if i % args.num_shards == args.shard]

--- a/preprocess/rotate_bvh_parallel.py
+++ b/preprocess/rotate_bvh_parallel.py
@@ -23,8 +23,17 @@ rotations = [
 ]
 save_names = ['y0', 'y15', 'y30', 'y45', 'y60', 'y75', 'y90', 'y135', 'y180', 'y225', 'y270', 'y315']
 
-bvh_directory = 'zoo/motions'
-output_directory = 'zoo/bvh'
+ZOO_ROOT = os.environ.get('ZOO_ROOT', 'zoo')
+
+# Prefer the +Z-aligned motions produced by align_character_face_zplus.py — that is
+# what the released dataset was built from. Fall back to the raw motions/ so runs
+# that predate the alignment stage keep behaving exactly as before.
+_aligned = os.path.join(ZOO_ROOT, 'motions_face_zplus')
+bvh_directory = os.environ.get('BVH_SRC') or (
+    _aligned if os.path.isdir(_aligned) else os.path.join(ZOO_ROOT, 'motions')
+)
+output_directory = os.path.join(ZOO_ROOT, 'bvh')
+print(f'[rotate_bvh] source: {bvh_directory} -> {output_directory}')
 os.makedirs(output_directory, exist_ok=True)
 
 def rotate_bvh(base_bvh_path, rotation, save_path):

--- a/preprocess/run_pipeline.sh
+++ b/preprocess/run_pipeline.sh
@@ -2,30 +2,39 @@
 # Run the full MocapAnything preprocessing pipeline end-to-end.
 #
 # Stages (in order):
-#   1. move_fbx        : flatten Truebone FBX files into character folders
-#   2. extract_char    : extract base mesh + per-motion BVH + rest pose (Blender)
-#   3. rotate_bvh      : rotate every motion BVH around Y axis x12
-#   4. extract_pose    : per-BVH pose npz (positions + rot6d + traj)
-#   5. render_videos   : render BVH+character into mp4 (Blender)
-#   6. extract_frames  : ffmpeg mp4 -> 30 fps PNG frames
-#   7. remesh          : voxel-remesh animated meshes per frame (Blender)
+#   1. move_fbx        : flatten raw FBX files into character folders
+#   2. fix_fbx         : drop no-weight leaf bones (3ds Max Biped `*Nub`) (Blender)
+#   3. extract_char    : base mesh + skinning + rest pose + per-motion BVH (Blender)
+#   4. align_faces     : rotate characters and motions to face +Z
+#   5. rotate_bvh      : rotate every motion BVH around Y axis x12
+#   6. extract_pose    : per-BVH pose npz (positions + rot6d + traj)
+#   7. species_info    : skeleton topology + joint-name T5 embeddings + static joints
+#   8. scale_cache     : per-species normalization scale
+#   9. render_videos   : render BVH+character into mp4 (Blender)
+#  10. extract_frames  : ffmpeg mp4 -> 30 fps PNG frames
+#  11. remesh          : voxel-remesh animated meshes per frame (Blender)
 #                        REQUIRES per-character animated mesh npz in $ZOO_ROOT/anim_meshes/
-#   8. rotate_meshes   : rotate remeshed meshes x12
-#   9. normalize       : per-species bbox normalization
-#  10. preprocess_data : VAE + DINOv2 encode -> npz_train (GPU)
-#  11. image_only      : strip latent -> npz_train_image_only
+#  12. rotate_meshes   : rotate remeshed meshes x12
+#  13. normalize       : per-species bbox normalization
+#  14. preprocess_data : VAE + DINOv2 encode -> npz_train (GPU)
+#  15. image_only      : strip latent -> npz_train_image_only
 #
-# Mesh-free alternative (skips stages 7-11 when you do not have anim_meshes):
-#  10b. preprocess_image_only : DINOv2 encode straight from image/ -> npz_train_image_only (GPU)
+# Mesh-free alternative (skips stages 11-15 when you do not have anim_meshes):
+#  14b. preprocess_image_only : DINOv2 encode straight from image/ -> npz_train_image_only (GPU)
+#
+# Stages 7 and 8 produce the two files inference refuses to run without:
+# species_info_dict.npy and cache/__mesh2pose1002_species_scale_cache.pkl.
 #
 # Usage:
 #   bash preprocess/run_pipeline.sh                              # run everything
 #   STAGES="rotate_meshes,normalize,preprocess_data" bash preprocess/run_pipeline.sh
 #   DATA_ROOT=Truebone_Z-OO ZOO_ROOT=zoo BLENDER=/path/to/blender bash preprocess/run_pipeline.sh
 #
-#   # Mesh-free path (no anim_meshes available):
-#   STAGES="move_fbx,extract_char,rotate_bvh,extract_pose,render_videos,extract_frames,preprocess_image_only" \
+#   # Mesh-free path (no anim_meshes available) — this is the path a custom rig takes:
+#   STAGES="move_fbx,fix_fbx,extract_char,align_faces,rotate_bvh,extract_pose,species_info,scale_cache,render_videos,extract_frames,preprocess_image_only" \
 #       bash preprocess/run_pipeline.sh
+#
+# See examples/custom_rig/README.md for bringing your own rigged FBX through this.
 
 set -euo pipefail
 
@@ -51,42 +60,84 @@ header() {
     echo "============================================================"
 }
 
+FBX_ROOT="${FBX_ROOT:-$DATA_ROOT}"      # what extract_char reads; fix_fbx redirects it
+
 if should_run move_fbx; then
-    header "1/11" "move_fbx"
+    header "1/15" "move_fbx"
     if [[ ! -d "$DATA_ROOT" ]]; then
-        echo "[ERROR] $DATA_ROOT does not exist; place Truebone FBX folders there first."
+        echo "[ERROR] $DATA_ROOT does not exist; place your character FBX folders there first."
         exit 1
     fi
     (cd "$DATA_ROOT" && bash "$REPO_ROOT/preprocess/move_fbx.sh")
 fi
 
+if should_run fix_fbx; then
+    header "2/15" "fix_fbx_batch (Blender)"
+    # 3ds Max Biped rigs carry `*Nub` leaf bones with no skin weights. They must go,
+    # or every downstream joint count differs from the released dataset.
+    "$PYTHON" preprocess/fix_fbx_batch.py \
+        --input_root "$DATA_ROOT" \
+        --output_root "$ZOO_ROOT/fixed_fbx" \
+        --blender "$BLENDER" \
+        --skip_existing
+    FBX_ROOT="$ZOO_ROOT/fixed_fbx"
+fi
+
 if should_run extract_char; then
-    header "2/11" "extract_character_from_fbx (Blender)"
-    "$BLENDER" --background --python preprocess/extract_character_from_fbx.py
+    header "3/15" "extract_character_from_fbx (Blender)"
+    # PYTHON is passed through: the face-forward pass needs torch, which Blender's
+    # bundled interpreter does not have, so that step shells out.
+    DATA_ROOT="$FBX_ROOT" PYTHON="$PYTHON" \
+        "$BLENDER" --background --python preprocess/extract_character_from_fbx.py
+fi
+
+if should_run align_faces; then
+    header "4/15" "align_character_face_zplus"
+    "$PYTHON" preprocess/align_character_face_zplus.py \
+        --input_root "$ZOO_ROOT/characters_fix_facezplus" \
+        --output_root "$ZOO_ROOT/characters_face_zplus" \
+        --motion_root "$ZOO_ROOT/motions" \
+        --motion_output_root "$ZOO_ROOT/motions_face_zplus" \
+        ${ALIGN_REF_DIR:+--ref_dir "$ALIGN_REF_DIR"}
 fi
 
 if should_run rotate_bvh; then
-    header "3/11" "rotate_bvh_parallel"
+    header "5/15" "rotate_bvh_parallel"
+    # Picks up motions_face_zplus/ automatically when align_faces has run.
     "$PYTHON" preprocess/rotate_bvh_parallel.py
 fi
 
 if should_run extract_pose; then
-    header "4/11" "extract_bvh_pose"
+    header "6/15" "extract_bvh_pose"
     "$PYTHON" preprocess/extract_bvh_pose.py
 fi
 
+if should_run species_info; then
+    header "7/15" "build_species_info (T5)"
+    "$PYTHON" preprocess/build_species_info.py --dataset_root "$ZOO_ROOT"
+fi
+
+if should_run scale_cache; then
+    header "8/15" "build_scale_cache"
+    "$PYTHON" preprocess/build_scale_cache.py \
+        --bvh_pose_root "$ZOO_ROOT/bvh_pose" \
+        --output "$ZOO_ROOT/cache/__mesh2pose1002_species_scale_cache.pkl"
+fi
+
 if should_run render_videos; then
-    header "5/11" "render_bvh_videos (Blender)"
-    "$PYTHON" preprocess/render_bvh_videos.py
+    header "9/15" "render_bvh_videos_fast (Blender)"
+    BLENDER="$BLENDER" "$PYTHON" preprocess/render_bvh_videos_fast.py \
+        --zoo-root "$ZOO_ROOT" \
+        --character-root "$ZOO_ROOT/characters_face_zplus"
 fi
 
 if should_run extract_frames; then
-    header "6/11" "video_to_images (ffmpeg)"
+    header "10/15" "video_to_images (ffmpeg)"
     "$PYTHON" preprocess/video_to_images.py
 fi
 
 if should_run remesh; then
-    header "7/11" "remesh_meshes (Blender)"
+    header "11/15" "remesh_meshes (Blender)"
     if [[ ! -d "$ZOO_ROOT/anim_meshes" ]]; then
         echo "[ERROR] $ZOO_ROOT/anim_meshes does not exist."
         echo "        Produce per-character animated mesh npz files (vertices, faces) there first."
@@ -98,14 +149,14 @@ if should_run remesh; then
 fi
 
 if should_run rotate_meshes; then
-    header "8/11" "rotate_meshes"
+    header "12/15" "rotate_meshes"
     "$PYTHON" preprocess/rotate_meshes.py \
         --input_root "$ZOO_ROOT/remesh_npz" \
         --output_root "$ZOO_ROOT/npz_remesh"
 fi
 
 if should_run normalize; then
-    header "9/11" "normalize_meshes"
+    header "13/15" "normalize_meshes"
     "$PYTHON" preprocess/normalize_meshes.py \
         --input_root "$ZOO_ROOT/npz_remesh" \
         --pose_root "$ZOO_ROOT/bvh_pose" \
@@ -113,19 +164,19 @@ if should_run normalize; then
 fi
 
 if should_run preprocess_data; then
-    header "10/11" "preprocess_data (VAE + DINOv2, GPU)"
+    header "14/15" "preprocess_data (VAE + DINOv2, GPU)"
     "$PYTHON" preprocess/preprocess_data.py --dataset_root "$ZOO_ROOT"
 fi
 
 if should_run image_only; then
-    header "11/11" "extract_image_only"
+    header "15/15" "extract_image_only"
     "$PYTHON" preprocess/extract_image_only.py \
         --input_root "$ZOO_ROOT/npz_train" \
         --output_root "$ZOO_ROOT/npz_train_image_only"
 fi
 
 if should_run preprocess_image_only; then
-    header "10b" "preprocess_image_only (DINOv2 only, GPU)"
+    header "14b" "preprocess_image_only (DINOv2 only, GPU)"
     "$PYTHON" preprocess/preprocess_image_only.py --dataset_root "$ZOO_ROOT"
 fi
 

--- a/utils/bvh_tools.py
+++ b/utils/bvh_tools.py
@@ -1,3 +1,6 @@
+import json
+import os
+import shutil
 from pathlib import Path
 
 import numpy as np
@@ -6,6 +9,11 @@ import torch
 from . import animation as animation
 from . import bvh as BVH
 from .transforms3d import *
+
+
+def save_json(pth, dict_list):
+    with open(pth, 'w', encoding='utf-8') as f:
+        json.dump(dict_list, f, ensure_ascii=False, indent=4)
 
 
 # ---------------------------------------------------------------------------
@@ -311,6 +319,178 @@ def get_diameter(parents, bone_length):
 
     b_l, b_p = get_one_end(a_p[-1], [])
     return b_l, b_p
+
+
+def compute_rest_joints(offsets: np.ndarray, parents: np.ndarray) -> np.ndarray:
+    """
+    Compute global joint positions in T-pose from BVH offsets and parent structure.
+    """
+    J = offsets.shape[0]
+    joints = np.zeros((J, 3))
+    for j in range(J):
+        if parents[j] < 0:
+            joints[j] = offsets[j]
+        else:
+            joints[j] = joints[parents[j]] + offsets[j]
+    return joints
+
+
+# --------------For Quadruped Restpose Alignment and Motion Mirroring ----------------------
+def fit_symmetry_plane(mid_joints_positions):
+    """
+    mid_joints_positions: (N,3)，顺序为 pelvis -> spine1 -> spine2 -> ...（已按从下到上或你定义的正向排序）
+    返回:
+      n:       (3,) 对称平面法向量（符号仍然不定，通常不强求）
+      mean:    (3,) 中心
+      v_spine: (3,) 脊柱主方向（已按输入顺序定向：第1点 -> 最后1点）
+      v_proj:  (3,) v_spine 在对称平面上的单位投影（与 v_spine 同号）
+    """
+    P = np.asarray(mid_joints_positions, dtype=np.float64)
+    mean = P.mean(axis=0)
+    X = P - mean
+
+    C = X.T @ X
+    eigvals, eigvecs = np.linalg.eigh(C)
+
+    # 最小方差 -> 平面法向；最大方差 -> 沿脊柱
+    n = eigvecs[:, 0]
+    v_spine = eigvecs[:, -1]
+
+    # 用“首尾向量”给 v_spine 定向（按你提供的顺序）---
+    ref_vec = P[-1] - P[0]  # pelvis → 最后一个脊柱点
+    if np.linalg.norm(ref_vec) > 0 and np.dot(v_spine, ref_vec) < 0:
+        v_spine = -v_spine
+
+    # 在对称平面上的投影，并用同一个参照向量的投影定向
+    v_proj = v_spine - n * np.dot(v_spine, n)
+    v_proj_norm = np.linalg.norm(v_proj)
+    v_proj /= v_proj_norm
+
+    return n, mean, v_spine / np.linalg.norm(v_spine), v_proj
+
+
+def quadruped_character_restpose_alignment(bvh_pth, save_dir, front=None):
+    character_align = False
+    file_name = os.path.basename(bvh_pth)
+    anim, names, frametime = BVH.load(bvh_pth)
+    pos_at_restpose = compute_rest_joints(anim.offsets, anim.parents)
+
+    if not type(front) == np.ndarray:
+        center, symmetry = find_symmetry(bvh_pth)
+        n, mean, v_spine, front = fit_symmetry_plane(
+            pos_at_restpose[np.array(center), :][1:]
+        )
+        symmetry_info = {'center': center, 'symmetry': symmetry}
+        save_json(save_dir + '/symmetry_info.json', [symmetry_info])
+
+    np.save(save_dir + '/front.npy', front)
+    mesh_pth = os.path.dirname(bvh_pth) + '/base_mesh.obj'
+    if os.path.exists(mesh_pth):
+        character_align = True
+
+    def rot_y(angle):
+        c, s = np.cos(angle), np.sin(angle)
+        return np.array(
+            [[c, 0., s], [0., 1., 0.], [-s, 0., c]], dtype=np.float64
+        )
+
+    global_trans = animation.transforms_global(anim)
+    global_pos = global_trans[:, :, :3, 3] / global_trans[:, :, 3, 3:]
+    # 1) 只绕Y对齐 front 到 +Z（避免 qbetween 的 180°退化）
+    front_y = front.copy()
+    front_y[1] = 0.0
+    nrm = np.linalg.norm(front_y)
+    if nrm < 1e-8:
+        yaw = 0.0 if front[2] >= 0 else np.pi
+    else:
+        front_y /= nrm
+        yaw = np.arctan2(front_y[0], front_y[2])  # from +Z to front_y
+    R = rot_y(yaw)  # 把 front 旋到 +Z；行向量右乘 v' = v @ R
+
+    # 2) offsets（restpose）在新基底
+    joints_pos_rot = pos_at_restpose @ R
+    offsets_list = [joints_pos_rot[0][None]]
+    for i in range(1, joints_pos_rot.shape[0]):
+        offsets_list.append(
+            (joints_pos_rot[i] - joints_pos_rot[anim.parents[i]])[None]
+        )
+    offsets = np.concatenate(offsets_list, axis=0)  # (J,3)
+
+    # 3) 所有关节局部旋转做换基：R_i' = R^T @ R_i @ R（行向量/右乘）
+    rotation_q = torch.from_numpy(anim.rotations.qs)  # (T,J,4)
+    rot_mat = quaternion_to_matrix(rotation_q)  # (T,J,3,3)
+    R_t = torch.tensor(R, dtype=rot_mat.dtype, device=rot_mat.device)
+    R_inv = R_t.t()
+    # 左乘 R^T
+    rot_mat = torch.einsum('ab,tjbc->tjac', R_inv, rot_mat)
+    # 右乘 R
+    rot_mat = torch.einsum('tjab,bc->tjac', rot_mat, R_t)
+
+    # 4) 根平移随 R 旋，其它关节平移为 0（BVH 规范）
+    seq_len = rot_mat.shape[0]
+    J = offsets.shape[0]
+    transl = (anim.positions - np.tile(anim.offsets,
+                                       (seq_len, 1, 1)))[:, 0]  # (T,3)
+    transl_rot = transl @ R  # (T,3)
+    positions = np.zeros((seq_len, J, 3), dtype=np.float32)
+    positions[:, 0] = transl_rot + anim.offsets[0][None]
+
+    # 5) 回欧拉（顺序与 BVH 'order' 完全一致）
+    euler = matrix_to_euler_angles(rot_mat, 'ZYX').cpu().numpy()
+    euler = np.degrees(euler)
+
+    bvh_data = {
+        'rotations': euler,
+        'positions': positions,
+        'offsets': offsets,
+        'parents': anim.parents,
+        'names': names,
+        'order': 'zyx',
+        'frametime': frametime,
+    }
+
+    # 6 转mesh, character 迁移 (如果有)
+    if character_align:
+        character_dir = os.path.dirname(bvh_pth)
+        shutil.copytree(character_dir, save_dir, dirs_exist_ok=True)
+        mesh_save_pth = os.path.join(save_dir, 'base_mesh.obj')
+        _rotate_obj_vertices_and_normals(mesh_pth, mesh_save_pth, R)
+
+    save_pth = os.path.join(save_dir, file_name)
+    BVH.save_dict(save_pth, bvh_data, fps=30)
+
+
+def _rotate_obj_vertices_and_normals(src_obj_path, dst_obj_path, R):
+    """
+    读取 .obj，行向量右乘：v' = v @ R, vn' = vn @ R；vt 不变；其它行原样抄写。
+    只处理 'v', 'vn', 'vt', 'f', 'usemtl', 'mtllib', 'o', 'g', 's' 常见行。
+    """
+    R = np.asarray(R, dtype=np.float64)
+    out_lines = []
+    with open(src_obj_path, 'r', encoding='utf-8', errors='ignore') as f:
+        for line in f:
+            if line.startswith('v '):  # 顶点
+                parts = line.strip().split()
+                v = np.array(list(map(float, parts[1:4])), dtype=np.float64)
+                v = v @ R
+                out_lines.append(f'v {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}\n')
+            elif line.startswith('vn '):  # 法线
+                parts = line.strip().split()
+                n = np.array(list(map(float, parts[1:4])), dtype=np.float64)
+                n = n @ R
+                # 归一化，避免数值误差
+                nn = np.linalg.norm(n)
+                if nn > 0:
+                    n /= nn
+                out_lines.append(f'vn {n[0]:.6f} {n[1]:.6f} {n[2]:.6f}\n')
+            else:
+                # 其它（vt/f/材质/组等）原样抄写
+                out_lines.append(line)
+
+    os.makedirs(os.path.dirname(dst_obj_path), exist_ok=True)
+    with open(dst_obj_path, 'w', encoding='utf-8') as f:
+        f.writelines(out_lines)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
… inference)

The preprocessing pipeline could not actually be run end to end: two files that every inference entry point requires had no generator in the repo, and several released scripts crashed outright. This closes those gaps so a user can bring their own rigged FBX and drive it with in-the-wild footage.

Bugs fixed:
- extract_character_from_fbx.py imported utils.bvh_tools (torch) at module level, but runs under Blender's bundled Python, which has no torch. The face-forward pass now shells out to $PYTHON instead.
- extract_character_from_fbx.py never wrote {character}_ffs.bvh, the rest-pose template utils/npy2bvh.py exports rotations against. Substituting rest.bvh silently produces a collapsed mesh (offsets are 100x too large).
- extract_bvh_pose.py unpacked 2 values from read_obj_mesh(), which returns 3.
- preprocess_image_only.py imported the whole TripoSG pipeline just to reach its DINOv2 half, making the mesh-free path depend on geometry weights it never uses. It now falls back to facebook/dinov2-large directly (verified to produce byte-identical embeddings).
- configs/inference/inference_video2pose2rot.yaml declared 12/10/24 layers and a checkpoint name that do not match the released weights (8/8/32, video2pos2rot_epoch60.pt), so CLI inference failed to load the state dict.

Missing pipeline stages, now added:
- build_species_info.py    -> species_info_dict.npy (topology, joint-name T5
                              embeddings, static joints)
- build_scale_cache.py     -> cache/__mesh2pose1002_species_scale_cache.pkl
- fix_fbx.py / fix_fbx_batch.py -> drop no-weight leaf bones (3ds Max Biped *Nub)
- align_character_face_zplus.py -> rotate characters and motions to face +Z
- utils/bvh_tools.py gains the four functions the alignment stage needs
  (compute_rest_joints, fit_symmetry_plane,
  quadruped_character_restpose_alignment, _rotate_obj_vertices_and_normals);
  no existing function is modified.

examples/custom_rig/ documents the whole path with a runner and an inference config, including what to do when the facing-direction or leaf-bone heuristics guess wrong.

Verified from a raw FBX through to a rendered result: the rebuilt artifacts match the released zoo1030 data for the same character exactly on joints_name, joints_distance, joint_relation and static_joints, with all BVH offsets identical.

demo/ is untouched, and none of the changed modules are reachable from it.