### PR TITLE
docs: clarify licence — MIT stated explicitly, third-party notices added

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Dao Thien Phong
+Copyright (c) 2026 Kehong Gong
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,17 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+--- THIRD-PARTY NOTICES ---
+
+preprocess/briarmbg.py is a copy of the RMBG-1.4 network definition from
+briaai/RMBG-1.4 (https://huggingface.co/briaai/RMBG-1.4). Copyright belongs to
+BRIA AI and it is licensed under BRIA's own terms, NOT the MIT licence above.
+
+RMBG-1.4 weights, facebook/dinov2-large and facebook/sam2.1-hiera-* are
+downloaded at runtime from their own repositories under their own licences and
+are not redistributed by this project.
+
+Animal motion data is derived from Truebones Zoo
+(https://truebones.gumroad.com/l/skZMC) and is subject to Truebones' terms.

--- a/README.md
+++ b/README.md
@@ -135,4 +135,14 @@ If you build on the V1 baselines, please also cite the underlying papers — `me
 
 ## License
 
-See the repository for license information.
+MIT — see [LICENSE](LICENSE). The released V2 weights are MIT as well.
+
+Two things in the pipeline are **not** covered by that grant and follow their own
+terms: `preprocess/briarmbg.py` (RMBG-1.4, © BRIA AI) and the Truebones Zoo
+motion data. See the third-party notice in [LICENSE](LICENSE).
+
+## Acknowledgements
+
+Animal motion data: [Truebones Zoo](https://truebones.gumroad.com/l/skZMC) by
+Truebones Motions Animation Studios. Motion files are not redistributed with
+this project.


### PR DESCRIPTION
Addresses #35.

The README's License section was a placeholder ("See the repository for license information") while `LICENSE` has always been MIT. This says so directly, and carves out the parts that are not ours to license.

**LICENSE**
- copyright holder updated
- new `THIRD-PARTY NOTICES` section: `preprocess/briarmbg.py` is BRIA AI's RMBG-1.4 network definition and is *not* covered by our MIT grant; RMBG-1.4 / DINOv2 / SAM2 weights are fetched at runtime and not redistributed; animal motion data derives from Truebones Zoo and follows their terms

**README.md**
- License section states MIT (code and V2 weights) and points at the third-party notice
- new Acknowledgements section crediting Truebones, as their terms request

Docs only — no code, config, or demo data touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)