### PR TITLE
docs: redesign the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,109 @@
-# MoCapAnything V2
+<h1 align="center">MoCapAnything V2</h1>
 
-**End-to-End Motion Capture for Arbitrary Skeletons from Monocular Videos**
-
-[🤗 **Try the live demo**](https://huggingface.co/spaces/kehong/MoCapAnythingV2) · [Project Page](https://animotionlab.github.io/MoCapAnythingV2/) · [Paper (arXiv)](https://arxiv.org/abs/2604.28130) · [Install & Run](RUN.md)
+<h3 align="center">
+  End-to-End Motion Capture for Arbitrary Skeletons
+</h3>
 
 <p align="center">
-  <a href="https://huggingface.co/spaces/kehong/MoCapAnythingV2"><img src="https://img.shields.io/badge/🤗%20Demo-Live%20on%20HF%20Spaces-yellow" alt="Live demo on HuggingFace Spaces" /></a>
-  <a href="https://huggingface.co/kehong/MoCapAnythingV2-weights"><img src="https://img.shields.io/badge/🤗%20Weights-HF%20Hub-blue" alt="Weights on HuggingFace" /></a>
-  <a href="https://arxiv.org/abs/2604.28130"><img src="https://img.shields.io/badge/arXiv-2604.28130-b31b1b" alt="arXiv" /></a>
+  Video &nbsp;→&nbsp; 3D Pose &nbsp;→&nbsp; BVH-ready Rotations
 </p>
 
-> ⚠️ **Unofficial code release.** This repository is a reimplementation based on the paper — use as a reference, not a reproduction.
+<p align="center">
+  <a href="https://huggingface.co/spaces/kehong/MoCapAnythingV2"><img src="https://img.shields.io/badge/🤗_Live_Demo-Try_Now-FFD21E" alt="Try the live demo" /></a>
+  <a href="https://animotionlab.github.io/MoCapAnythingV2/"><img src="https://img.shields.io/badge/Project-Page-4C8BF5" alt="Project page" /></a>
+  <a href="https://arxiv.org/abs/2604.28130"><img src="https://img.shields.io/badge/arXiv-2604.28130-B31B1B" alt="Paper on arXiv" /></a>
+  <a href="https://huggingface.co/kehong/MoCapAnythingV2-weights"><img src="https://img.shields.io/badge/🤗_Model-Weights-FFD21E" alt="Model weights" /></a>
+  <a href="https://huggingface.co/datasets/kehong/MoCapAnythingV2-data"><img src="https://img.shields.io/badge/🤗_Training-Data-FFD21E" alt="Full training data (gated)" /></a>
+  <a href="https://huggingface.co/datasets/kehong/MoCapAnythingV2-data-sample"><img src="https://img.shields.io/badge/🤗_Demo-Data-FFD21E" alt="Demo data" /></a>
+</p>
 
 <p align="center">
-  <a href="https://animotionlab.github.io/MoCapAnythingV2/" title="Click to watch the 90-second teaser on the project page">
-    <img src="assets/teaser_play.png" width="92%" alt="MoCapAnything V2 teaser — click to watch the video on the project page" />
+  <a href="https://animotionlab.github.io/MoCapAnythingV2/" title="Watch the 90-second teaser">
+    <img src="assets/teaser.png" width="100%" alt="MoCapAnything V2: monocular video to motion capture for arbitrary skeletons" />
   </a>
 </p>
 
-<p align="center"><sub>▶ Click the image to watch the 90-second teaser on the project page.</sub></p>
+<p align="center">
+  <a href="https://animotionlab.github.io/MoCapAnythingV2/">▶ Watch the 90-second teaser</a>
+  &nbsp;·&nbsp;
+  <a href="RUN.md">Install &amp; Run</a>
+  &nbsp;·&nbsp;
+  <a href="RUN.md#metrics--reproduction">Reproduce the results</a>
+</p>
 
-## Updates
+MoCapAnything V2 directly predicts animation-ready joint rotations from a monocular video and a reference skeleton. It supports animals, humans, objects, and custom rigs without relying on a template-specific body model.
 
-- **[2026-05-01]** — 🎉 Code released: end-to-end `video2pose2rot` inference + the release training pipeline.
-- **[2026-07-13]** — 🏋️ Pretrained weights on HuggingFace (`kehong/MoCapAnythingV2-weights`).
-- **[2026-07-13]** — 🎮 Local interactive demo (`demo/app.py`) + demo data on HuggingFace.
-- **[2026-07-13]** — 💃 Dance Anything tab: dance video (with music) → SAM2 picks the dancer → animal performs the dance with the original audio.
-- **[2026-07-15]** — 🌐 **[Live online demo on HuggingFace Spaces](https://huggingface.co/spaces/kehong/MoCapAnythingV2)** (ZeroGPU, free) — try it in the browser, no setup: interactive 3D pose + mesh, retargeting, and Dance Anything.
-- **[2026-07-15]** — 🖼️ Interactive 3D + shareable **input | skeleton | mesh** clip rendered without Blender (works on Spaces); SAM2 via `transformers`; textured meshes.
-- **[2026-09-04]** — 📦 **[Full training data on HuggingFace](https://huggingface.co/datasets/kehong/MoCapAnythingV2-data)** (`zoo1030` + `obj1k`, ~25 GB) — **gated**: get [Truebones Zoo](https://truebones.gumroad.com/l/skZMC) from Truebones yourself first (it's pay-what-you-want), then request access; approvals are manual. Per-frame DINOv2 features are not shipped — regenerate them with `preprocess/`.
-- **[2026-09-04]** — 📊 Released train/test splits now ship in the repo, and [RUN.md](RUN.md#metrics--reproduction) documents the reproduction commands, the expected metrics, and how they differ from the paper.
+- **End-to-end motion capture.** Video → pose → rotation, jointly optimized without analytical IK.
+- **Arbitrary skeletons.** Drive released assets or bring your own rigged FBX character.
+- **Mesh-free and fast.** Predict joints directly from video—approximately 20× faster than mesh-based pipelines.
+
+> **About this release:** This is a clean reimplementation of the method, not the original research code that produced the paper's experiments. See [Metrics & Reproduction](RUN.md#metrics--reproduction) for what it reproduces and where it differs from the paper.
+
+## What's new
+
+- **[2026-09-04]** — 📦 [Full training data](https://huggingface.co/datasets/kehong/MoCapAnythingV2-data) (`zoo1030` + `obj1k`, ~25 GB) — **gated**: get [Truebones Zoo](https://truebones.gumroad.com/l/skZMC) from Truebones yourself first (it's pay-what-you-want), then request access. Per-frame DINOv2 features are not shipped; regenerate them with `preprocess/`.
+- **[2026-09-04]** — 📊 Released train/test splits now ship in the repository, and [RUN.md](RUN.md#metrics--reproduction) documents the reproduction commands, both training settings, the expected metrics, and how they differ from the paper.
+- **[2026-07-15]** — 🌐 [Live Hugging Face demo](https://huggingface.co/spaces/kehong/MoCapAnythingV2) (ZeroGPU, free) with interactive 3D pose, mesh rendering, retargeting, and Dance Anything — no setup required.
+- **[2026-07-13]** — 🏋️ [Pretrained V2 weights](https://huggingface.co/kehong/MoCapAnythingV2-weights) and [demo data](https://huggingface.co/datasets/kehong/MoCapAnythingV2-data-sample) released, alongside the local interactive demo (`demo/app.py`).
+- **[2026-07-13]** — 💃 Dance Anything: a dance video with music → SAM2 picks the dancer → the target creature performs it, re-muxed with the original audio.
+- **[2026-05-01]** — 🎉 End-to-end `video2pose2rot` inference and the release training pipeline released.
 
 <p align="center">
-  <img src="assets/demo_app.png" width="92%" alt="MocapAnything V2 interactive demo — pick a video, pick a target species/object, run: pose skeleton + 3D mesh render, with retargeting and a Dance Anything tab" />
+  <img src="assets/demo_app.png" width="92%" alt="MoCapAnything V2 interactive demo with pose, mesh, retargeting, and Dance Anything" />
 </p>
-<p align="center"><sub>🎮 The interactive demo — <code>python demo/app.py</code>, pick a video + target, hit Run.</sub></p>
-
-## Highlights
-
-- 🔗 **Fully end-to-end.** Video → Pose → Rotation jointly optimized — no analytical IK in the loop.
-- ⚓ **Reference-anchored rotation.** A single reference pose–rotation pair from the target asset defines the rotation coordinate system, turning pose-to-rotation into a well-constrained problem.
-- ⚡ **Mesh-free and fast.** Joints predicted directly from video, ~20× faster than mesh-based pipelines.
-- 🎮 **Interactive web demo** — [try it live on HuggingFace Spaces](https://huggingface.co/spaces/kehong/MoCapAnythingV2) (free, no setup) or run `demo/app.py` locally (same code). Two tabs: **Mocap · Retarget** (video → interactive 3D pose skeleton + textured mesh, plus a synced *input | skeleton | mesh* clip and `.npy` / BVH / glb downloads) and **💃 Dance Anything** (drop a dance video with music → SAM2 picks the dancer → a target creature performs the dance, re-muxed with the original audio). The online build renders in pure Python (no Blender/GL); locally, Blender adds an optional photorealistic render.
+<p align="center"><sub>Run locally with <code>python demo/app.py</code>, or try it directly in your browser.</sub></p>
 
 ## Pipeline
 
-The V2 main model is **`video2pose2rot`** — a single end-to-end network that maps a video directly to BVH-ready joint rotations. Internally it composes two subtasks, `video2pose` and `pose2rot`, that share weights and are jointly fine-tuned; they can be run standalone (e.g. for ablations or debugging), but normal usage is the joint model. The V1 mesh-based pipeline (`video2mesh` + `mesh2pose`) is included as a baseline for comparison.
+The V2 main model is **`video2pose2rot`**—a single end-to-end network that maps a video directly to BVH-ready joint rotations. Internally, it composes two jointly fine-tuned subtasks, `video2pose` and `pose2rot`. Both can also run independently for ablations and debugging. The V1 mesh-based pipeline (`video2mesh` + `mesh2pose`) is included as a baseline.
 
 | Stage | Role | Input | Output |
 | --- | --- | --- | --- |
-| **`video2pose2rot`** | **V2 — main end-to-end model** | Image sequence + reference | Joint rotations (BVH) |
-| &nbsp;&nbsp;↳ `video2pose` | V2 subtask (standalone-runnable) | Image sequence + reference pose | Joint positions |
-| &nbsp;&nbsp;↳ `pose2rot` | V2 subtask (standalone-runnable) | Joint positions + rest pose / reference pose-rot pair | Joint rotations |
-| `video2mesh` | V1 baseline — mesh sequence (TripoSG) | Image sequence | Mesh (`.glb` / latent) |
-| `mesh2pose` | V1 baseline — joints from per-frame meshes | Mesh sequence + reference pose | Joint positions |
+| **`video2pose2rot`** | **V2 main model** | Image sequence + reference | Joint rotations (BVH) |
+| &nbsp;&nbsp;↳ `video2pose` | V2 subtask | Image sequence + reference pose | Joint positions |
+| &nbsp;&nbsp;↳ `pose2rot` | V2 subtask | Joint positions + reference pose–rotation pair | Joint rotations |
+| `video2mesh` | V1 baseline | Image sequence | Mesh (`.glb` / latent) |
+| `mesh2pose` | V1 baseline | Mesh sequence + reference pose | Joint positions |
 
 A reference frame from a matching species guides the per-species skeleton and scale, enabling generalization to unseen animals.
 
-## Quick Start
+## Quick start
 
-Clone the repo, grab the weights + demo data from HuggingFace, and run the bundled examples (or your own videos) end-to-end — no dataset preprocessing required.
+Clone the repository, download the weights and demo data, and run the bundled examples—or use your own videos. Dataset preprocessing is not required for inference.
 
 ```bash
 pip install torch torchvision numpy opencv-python pillow matplotlib scipy scikit-image trimesh roma pyyaml tqdm huggingface_hub transformers gradio imageio-ffmpeg
 
-# Weights → ./checkpoints/   ·   Demo data (~160 MB, 1-frame references) → ./demo/data/
+# Weights → ./checkpoints/ · Demo data → ./demo/data/
 hf download kehong/MoCapAnythingV2-weights --local-dir ./checkpoints
 hf download kehong/MoCapAnythingV2-data-sample --repo-type dataset --local-dir ./demo/data
 
-# Command-line inference (zoo / obj / in-the-wild)
+# Command-line inference
 python inference/video2pose2rot.py --config demo/configs/demo_zoo.yaml
 
-# …or the interactive web demo
-python demo/app.py            # http://localhost:7860
+# Or launch the interactive demo at http://localhost:7860
+python demo/app.py
 ```
 
-> The 3D mesh render needs a portable [Blender](https://www.blender.org/download/) build (4.x/5.x): extract it and `export BLENDER_BIN=/path/to/blender` — without it you still get pose `.npy` + BVH + skeleton videos. Checkpoints and datasets live on HuggingFace; only code ships in this repo. The background remover (`briaai/RMBG-1.4`) and DINOv2 auto-download on first run. If torch complains your NVIDIA driver is too old, install a build matching your driver from [pytorch.org](https://pytorch.org/get-started/locally/) (tested: `torch==2.9.0`).
+> The optional textured 3D mesh render requires a portable [Blender](https://www.blender.org/download/) 4.x/5.x build and `BLENDER_BIN=/path/to/blender`. Without Blender, the pipeline still produces pose `.npy`, BVH, and skeleton videos. The background remover (`briaai/RMBG-1.4`) and DINOv2 download on first use. If PyTorch reports that the NVIDIA driver is too old, install a build compatible with your driver from [pytorch.org](https://pytorch.org/get-started/locally/).
 
-## Use your own rigged character
+For environment setup, dataset layout, training, inference, and troubleshooting, see **[Install & Run](RUN.md)**.
 
-The preprocessing pipeline is not tied to the released datasets. Point it at your own rigged
-FBX and it produces the same artifacts inference consumes — skeleton topology, joint-name
-embeddings, reference poses — so you can drive *your* rig with in-the-wild footage.
+## Training and reproduction
+
+Two settings were trained; we release **Setting A**. Both are documented, and either can be
+trained from this repository:
+
+- **Setting A** — the released recipe, with reference-frame augmentation. Better retargeting and in-the-wild results.
+- **Setting B** — no reference-frame augmentation. Better benchmark numbers.
+
+Commands, the full hyper-parameters for both, the metrics each produces, and how they compare
+to the paper are in **[Metrics & Reproduction](RUN.md#metrics--reproduction)**. The train/test
+splits ship in [`datasets/`](datasets/).
+
+## Bring your own rig
+
+The preprocessing pipeline is not tied to the released datasets. Point it at your own rigged FBX to generate the skeleton topology, joint-name embeddings, and reference poses consumed by inference.
 
 ```bash
 export BLENDER=/path/to/blender PYTHON=/path/to/torch/python
@@ -89,18 +111,11 @@ bash examples/custom_rig/run.sh MyRig
 python -m inference.video2pose2rot --config examples/custom_rig/inference.yaml
 ```
 
-Walkthrough, required file layout, and troubleshooting: **[examples/custom_rig/README.md](examples/custom_rig/README.md)**.
-Stage-by-stage reference: **[preprocess/README.md](preprocess/README.md)**.
-
-## Install & Run
-
-Environment setup, dataset layout, training commands, and inference (including in-the-wild mode) live in **[RUN.md](RUN.md)**.
-
-Reproduction commands, the expected metrics for the released checkpoint, and how they differ from the paper: **[RUN.md → Metrics & Reproduction](RUN.md#metrics--reproduction)**.
+See the **[custom-rig walkthrough](examples/custom_rig/README.md)** for the required layout and troubleshooting, or the **[preprocessing reference](preprocess/README.md)** for every stage.
 
 ## Citation
 
-If you use this code, please consider cite:
+If you use this code, please consider citing:
 
 ```bibtex
 @article{gong2026mocapanythingv2,
@@ -114,7 +129,7 @@ If you use this code, please consider cite:
 }
 ```
 
-If you build on the V1 baselines, please also cite the underlying papers — `mesh2pose` is from **MoCapAnything (V1)**, and `video2mesh` is from **SWiT-4D**:
+If you build on the V1 baselines, please also cite the corresponding papers: `mesh2pose` comes from **MoCapAnything (V1)**, and `video2mesh` comes from **SWiT-4D**.
 
 ```bibtex
 @InProceedings{Gong_2026_CVPR,


### PR DESCRIPTION
Centred title block, badge row, tighter Updates list (reverse chronological), and a new **Training and reproduction** section that says plainly which setting is the released one.

Also fixes the subtitle — the V2 paper is titled *End-to-End Motion Capture for Arbitrary Skeletons*; the trailing *from Monocular Videos* is V1's title and had been carried over by mistake.

Licence section, third-party notice and acknowledgements carry over unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)